### PR TITLE
Add ENABLE_CK build arg for fast Triton-only AITER builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ ARG AITER_COMMIT="HEAD"
 ARG MORI_COMMIT="b0dce4beebeb1f26c784eee17d5fd9785ee9447f"
 ARG PREBUILD_KERNELS=1
 ARG MAX_JOBS
+# Set ENABLE_CK=0 to skip CK/ASM modules for a fast Triton-only AITER build
+ARG ENABLE_CK=1
 
 RUN pip install --upgrade pip
 RUN pip install lm-eval[api]
@@ -70,8 +72,11 @@ RUN git clone $AITER_REPO /app/aiter-test && \
     cd /app/aiter-test && \
     pip install -r requirements.txt && \
     git checkout $AITER_COMMIT && \
-    git submodule sync && git submodule update --init --recursive && \
-    MAX_JOBS=$MAX_JOBS PREBUILD_KERNELS=$PREBUILD_KERNELS GPU_ARCHS=$GPU_ARCH_LIST python3 setup.py develop
+    if [ "$ENABLE_CK" != "0" ]; then \
+        git submodule sync && git submodule update --init --recursive; \
+    fi && \
+    ENABLE_CK=$ENABLE_CK MAX_JOBS=$MAX_JOBS PREBUILD_KERNELS=$PREBUILD_KERNELS \
+        GPU_ARCHS=$GPU_ARCH_LIST python3 setup.py develop
 RUN pip show amd-aiter || true
 
 


### PR DESCRIPTION
## Summary
- Add `ENABLE_CK` Docker build arg (default=1) that controls whether AITER builds with CK/ASM modules
- When `ENABLE_CK=0`: skips CK submodule clone and excludes 45 CK-dependent modules, building only 32 Triton + utility modules
- Default `ENABLE_CK=1` preserves existing full-build behavior

## Usage
```bash
# Fast build (Triton-only AITER)
docker build --build-arg ENABLE_CK=0 -f docker/Dockerfile .

# Full build (existing behavior, unchanged)
docker build -f docker/Dockerfile .
```

## Depends on
- ROCm/aiter ENABLE_CK=0 support (PR pending)

## Test Results
Verified on bare-metal with `ENABLE_CK=0 PREBUILD_KERNELS=1`:
- 31/32 AITER KEEP modules built (1 pre-existing LLVM bug)
- 9 AITER operator unit tests passed
- 115/115 ATOM unit tests passed