### PR TITLE
Enable Triton-only prefill attention and ENABLE_CK Docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ ARG AITER_COMMIT="HEAD"
 ARG MORI_COMMIT="b0dce4beebeb1f26c784eee17d5fd9785ee9447f"
 ARG PREBUILD_KERNELS=1
 ARG MAX_JOBS
+# Set ENABLE_CK=0 to skip CK/ASM modules for a fast Triton-only AITER build
+ARG ENABLE_CK=1
 
 RUN pip install --upgrade pip
 RUN pip install lm-eval[api]
@@ -63,6 +65,10 @@ RUN git clone --depth=1 --branch release/internal/3.5.x https://github.com/ROCm/
   MAX_JOBS=64 pip --retries=10 --default-timeout=60 install .
 RUN pip show triton || true
 
+# Install triton_kernels (required for MXFP4 MoE on gfx94x)
+RUN pip install --no-deps -e /triton-test/python/triton_kernels/
+RUN pip show triton-kernels || true
+
 # Install Aiter
 RUN mkdir -p /app
 RUN pip uninstall -y aiter || true
@@ -70,8 +76,11 @@ RUN git clone $AITER_REPO /app/aiter-test && \
     cd /app/aiter-test && \
     pip install -r requirements.txt && \
     git checkout $AITER_COMMIT && \
-    git submodule sync && git submodule update --init --recursive && \
-    MAX_JOBS=$MAX_JOBS PREBUILD_KERNELS=$PREBUILD_KERNELS GPU_ARCHS=$GPU_ARCH_LIST python3 setup.py develop
+    if [ "$ENABLE_CK" != "0" ]; then \
+        git submodule sync && git submodule update --init --recursive; \
+    fi && \
+    ENABLE_CK=$ENABLE_CK MAX_JOBS=$MAX_JOBS PREBUILD_KERNELS=$PREBUILD_KERNELS \
+        GPU_ARCHS=$GPU_ARCH_LIST python3 setup.py develop
 RUN pip show amd-aiter || true
 
 


### PR DESCRIPTION
## Summary
- Route prefill attention to Triton path (`prefill_attention_triton`) when `use_triton_attn=True` (head_dim!=128 or sliding_window models)
- Create `fake_block_tables` inline from `cu_seqlens_k` — the field was never populated, causing NoneType errors
- Dockerfile: add `ENABLE_CK` build arg, install `triton_kernels` package, conditionally skip CK submodule init

## Problem
1. `dispatch_backend()` always routed prefill to CK-based `flash_attn_varlen_func`, which fails with `ENABLE_CK=0` AITER builds
2. `attn_metadata.fake_block_tables` is declared in `AttentionMetaData` but never populated anywhere
3. Docker image lacked `triton_kernels` package (required for MXFP4 MoE on gfx94x)

## Related
- AITER companion PR: sunway513/aiter#13
- Dependency: `triton_kernels` package from `ROCm/triton` (`pip install --no-deps -e /triton/python/triton_kernels/`)

## Test plan
- [x] Verified with GPT-OSS-120B (120B MoE, head_dim=64, MXFP4, sliding_window=128) on MI300X
- [x] Docker image `rocm/atom-private:triton-only-ck0` built and tested (108/115 UTs pass)
- [x] TTFT ~3.57s, TPOT ~10ms, correct outputs on all test prompts
- [ ] Run full ATOM unit test suite