### PR TITLE
Fix DeepSeek R1 for Triton-only build (ENABLE_CK=0)

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -419,9 +419,8 @@ class Attention(nn.Module):
         ctx = fwd_ctx.context
 
         if ctx.is_prefill:
-            if self.use_triton_attn:
-                return self.prefill_attention_triton
-            return self.prefill_attention
+            # Always use Triton prefill (no CK/flash_attn_varlen_func dependency)
+            return self.prefill_attention_triton
         else:
             if self.use_triton_attn:
                 return self.paged_attention_triton


### PR DESCRIPTION
## Summary
- **MOE**: Handle fused shared expert top_k mismatch — when shared experts are fused, `topk_ids` has `M*(top_k+1)` elements. Added `actual_top_k = topk_ids.numel() // M` and used throughout `_triton_fp8_moe`.
- **MLA prefill**: Replace `flash_attn_varlen_func` (requires CK module `module_fmha_v3_varlen_fwd`) with PyTorch `F.scaled_dot_product_attention` — removes CK dependency for MLA prefill path.
- **MHA prefill**: Always dispatch to `prefill_attention_triton` in `dispatch_backend()` — DeepSeek layer 0 uses standard MHA (not MLA), which also called `flash_attn_varlen_func`.
- **aiter_mla prepare_prefill**: Populate paged KV metadata (`kv_indptr`, `kv_indices`, `kv_last_page_lens`, `block_tables`) needed by MLA Triton prefill paths.

## Test plan
- [x] DeepSeek R1 671B, 8x MI300X, `atom:clean-multistage` (ENABLE_CK=0)
- [x] Benchmark: ISL=1024, OSL=1024, concurrency=128, 1280 prompts
- [x] Results: 1504 tok/s output throughput, 77ms median TPOT, 5.5s median TTFT
- [x] All 1280 requests completed successfully