### PR TITLE
Add FlyDSL MOE backend and Triton fallback for FP8 MoE

### DIFF
--- a/atom/model_ops/flydsl_moe.py
+++ b/atom/model_ops/flydsl_moe.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
+
+"""FlyDSL MOE backend for ATOM.
+
+When CK MOE sorting is unavailable (e.g. AITER built with ENABLE_CK=0) and
+ATOM_USE_FLYDSL_MOE=1, this module routes FP8 MOE through FlyDSL's MLIR-compiled
+2-stage kernels instead of the Triton fallback.
+
+Priority: CK/ASM > FlyDSL > Triton.
+"""
+
+import logging
+import os
+from typing import Optional, Tuple
+
+import torch
+
+from atom.utils import envs
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+_flydsl_moe_available: Optional[bool] = None
+
+
+def _has_flydsl_moe() -> bool:
+    """Check if FlyDSL MOE backend is enabled and importable."""
+    global _flydsl_moe_available
+    if _flydsl_moe_available is not None:
+        return _flydsl_moe_available
+
+    if not envs.ATOM_USE_FLYDSL_MOE:
+        _flydsl_moe_available = False
+        return False
+
+    try:
+        from kernels.moe_gemm_2stage import (
+            compile_moe_gemm1,
+            compile_moe_gemm2,
+        )  # noqa: F401
+
+        _flydsl_moe_available = True
+        _logger.info("FlyDSL MOE kernels detected and available")
+    except Exception as e:
+        _flydsl_moe_available = False
+        _logger.warning(
+            "ATOM_USE_FLYDSL_MOE=1 but FlyDSL MOE kernels not importable: %s. "
+            "Ensure FlyDSL repo is on PYTHONPATH.",
+            e,
+        )
+    return _flydsl_moe_available
+
+
+# ---------------------------------------------------------------------------
+# Torch-native MOE sorting (no CK dependency)
+# ---------------------------------------------------------------------------
+def moe_sorting_torch_native(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_experts: int,
+    block_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch MOE sorting matching CK/FlyDSL kernel expectations.
+
+    Returns:
+        sorted_ids: int32 with packed (topk_slot<<24 | token_id) encoding
+        sorted_weights: fp32 aligned with sorted_ids
+        sorted_expert_ids: int32, one expert id per M-block
+        num_tokens_post_pad: int32 [2], [0]=total padded tokens, [1]=num_tokens
+    """
+    device = topk_ids.device
+    M = topk_ids.shape[0]
+    topk = topk_ids.shape[1]
+
+    max_num_tokens_padded = topk_ids.numel() + num_experts * block_size - topk
+    max_num_m_blocks = (max_num_tokens_padded + block_size - 1) // block_size
+
+    init_val = (topk << 24) | M
+    sorted_ids = torch.full(
+        (max_num_tokens_padded,), init_val, dtype=torch.int32, device=device
+    )
+    sorted_weights = torch.empty(
+        (max_num_tokens_padded,), dtype=torch.float32, device=device
+    )
+    sorted_expert_ids = torch.full(
+        (max_num_m_blocks,), -1, dtype=torch.int32, device=device
+    )
+    num_tokens_post_pad = torch.empty((2,), dtype=torch.int32, device=device)
+
+    sorted_ids_begin = 0
+    sorted_expert_ids_begin = 0
+    skip_expert_num = 0
+    for expert_id in range(num_experts):
+        token_id, topk_id = torch.where(topk_ids == expert_id)
+        tokens_num = token_id.numel()
+        sorted_expert_ids_num = (tokens_num + block_size - 1) // block_size
+        tokens_num_pad = sorted_expert_ids_num * block_size
+
+        sorted_ids[sorted_ids_begin : sorted_ids_begin + tokens_num] = (
+            topk_id.to(torch.int32) << 24
+        ) | token_id.to(torch.int32)
+        sorted_weights[sorted_ids_begin : sorted_ids_begin + tokens_num] = topk_weights[
+            token_id, topk_id
+        ].to(torch.float32)
+
+        sorted_ids_begin += tokens_num_pad
+        sorted_expert_ids[
+            sorted_expert_ids_begin : sorted_expert_ids_begin + sorted_expert_ids_num
+        ] = (expert_id - skip_expert_num)
+        sorted_expert_ids_begin += sorted_expert_ids_num
+
+    num_tokens_post_pad[0] = sorted_ids_begin
+    num_tokens_post_pad[1] = M
+
+    return sorted_ids, sorted_weights, sorted_expert_ids, num_tokens_post_pad
+
+
+# ---------------------------------------------------------------------------
+# Per-token FP8 quantization
+# ---------------------------------------------------------------------------
+def _pertoken_quant_fp8(
+    x: torch.Tensor, fp8_dtype: torch.dtype
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Per-row dynamic FP8 quantization.
+
+    Args:
+        x: Input tensor, any shape with last dim as the quant dimension.
+        fp8_dtype: Target FP8 dtype.
+
+    Returns:
+        x_fp8: Quantized tensor (same shape as x).
+        scale_1d: 1D scale tensor [num_rows].
+    """
+    orig_shape = x.shape
+    x_2d = x.reshape(-1, orig_shape[-1]).float()
+    fp8_max = torch.finfo(fp8_dtype).max
+    amax = x_2d.abs().amax(dim=-1, keepdim=True)  # [rows, 1]
+    scale = (amax / fp8_max).clamp(min=1e-12)
+    x_scaled = (x_2d / scale).clamp(-fp8_max, fp8_max)
+    x_fp8 = x_scaled.to(fp8_dtype).reshape(orig_shape)
+    scale_1d = scale.view(-1).to(torch.float32)
+    return x_fp8, scale_1d
+
+
+# ---------------------------------------------------------------------------
+# FlyDSL FP8 MOE dispatch
+# ---------------------------------------------------------------------------
+def flydsl_fp8_moe(
+    x: torch.Tensor,
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    top_k: int,
+    block_quant: bool,
+    quant_type,
+) -> torch.Tensor:
+    """Execute FP8 MOE using FlyDSL MLIR-compiled 2-stage kernels.
+
+    Drop-in replacement for _triton_fp8_moe(). Expects preshuffled weights
+    (same CK layout as ASM/CK path).
+
+    Pipeline:
+        1. Sort tokens via torch-native MOE sorting
+        2. Quantize activations to FP8
+        3. Stage 1: GEMM1 + SiLU gating  (x @ w13^T)
+        4. Quantize intermediate to FP8
+        5. Stage 2: GEMM2 with atomic accumulation (intermediate @ w2^T)
+    """
+    from kernels.moe_gemm_2stage import compile_moe_gemm1, compile_moe_gemm2
+
+    if block_quant:
+        raise NotImplementedError(
+            "FlyDSL MOE does not support block quantization yet. "
+            "Set ATOM_USE_FLYDSL_MOE=0 or use Triton fallback."
+        )
+
+    M, model_dim = x.shape
+    E = w13.shape[0]
+    inter_dim_2 = w13.shape[1]  # 2 * inter_dim
+    inter_dim = inter_dim_2 // 2
+    actual_top_k = topk_ids.numel() // M
+    device = x.device
+
+    # Detect FP8 dtype from weight dtype
+    fp8_dtype = w13.dtype
+
+    # Tile sizes (configurable via env vars)
+    tile_m = int(os.environ.get("ATOM_FLYDSL_MOE_TILE_M", "64"))
+    tile_n = int(os.environ.get("ATOM_FLYDSL_MOE_TILE_N", "128"))
+    tile_k = int(os.environ.get("ATOM_FLYDSL_MOE_TILE_K", "64"))
+
+    # --- Step 1: Sort tokens ---
+    sorted_ids, sorted_weights, sorted_expert_ids, num_tokens_post_pad = (
+        moe_sorting_torch_native(
+            topk_ids.to(torch.int32),
+            topk_weights.to(torch.float32),
+            num_experts=E,
+            block_size=tile_m,
+        )
+    )
+    num_valid_ids = num_tokens_post_pad[:1].contiguous()
+    blocks = sorted_expert_ids.numel()
+
+    # --- Step 2: Compile kernels (cached via @lru_cache) ---
+    exe1 = compile_moe_gemm1(
+        model_dim=model_dim,
+        inter_dim=inter_dim,
+        experts=E,
+        topk=actual_top_k,
+        in_dtype="fp8",
+        tile_m=tile_m,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        doweight_stage1=False,
+    )
+    exe2 = compile_moe_gemm2(
+        model_dim=model_dim,
+        inter_dim=inter_dim,
+        experts=E,
+        topk=actual_top_k,
+        in_dtype="fp8",
+        tile_m=tile_m,
+        tile_n=tile_n,
+        tile_k=tile_k,
+        doweight_stage2=True,
+    )
+
+    # --- Step 3: Quantize activations ---
+    x_fp8, scale_x = _pertoken_quant_fp8(x, fp8_dtype)
+    x_fp8 = x_fp8.contiguous().view(M, model_dim)
+    scale_x_1d = scale_x.view(-1).contiguous()
+
+    # --- Step 4: Flatten weights for FlyDSL (expert dim merged into N) ---
+    # w13: [E, 2*inter_dim, model_dim] -> [E*2*inter_dim, model_dim]
+    w13_flat = w13.contiguous().view(E * inter_dim_2, model_dim)
+
+    # --- Step 5: Flatten weight scales ---
+    # Handle different scale shapes:
+    #   per-tensor: [E] -> broadcast to [E*2*inter_dim]
+    #   per-channel: [E, 2*inter_dim, 1] -> [E*2*inter_dim]
+    #   per-tensor (after max reduction): [E] -> broadcast
+    if w13_scale.dim() == 1:
+        # per-tensor [E]: broadcast each expert's scale to all its rows
+        scale_w13_1d = (
+            w13_scale.unsqueeze(1).expand(E, inter_dim_2).contiguous().view(-1)
+        )
+    elif w13_scale.dim() == 3:
+        # per-channel [E, 2*inter_dim, 1]
+        scale_w13_1d = w13_scale.contiguous().view(-1)
+    elif w13_scale.dim() == 2:
+        # [E, 2*inter_dim] or [E, 2] -> handle both
+        if w13_scale.shape[1] == inter_dim_2:
+            scale_w13_1d = w13_scale.contiguous().view(-1)
+        else:
+            # [E, 2] per-tensor per-shard -> broadcast
+            scale_w13_1d = (
+                w13_scale.unsqueeze(2).expand(E, 2, inter_dim).contiguous().view(-1)
+            )
+    else:
+        scale_w13_1d = w13_scale.contiguous().view(-1)
+
+    # --- Step 6: Stage 1 (GEMM1 + SiLU) ---
+    out1 = torch.empty((M, actual_top_k, inter_dim), device=device, dtype=torch.float16)
+    stream_ptr = torch.cuda.current_stream().cuda_stream
+
+    exe1(
+        out1,
+        x_fp8,
+        w13_flat,
+        scale_x_1d,
+        scale_w13_1d,
+        sorted_ids,
+        sorted_expert_ids,
+        sorted_weights.view(-1),
+        num_valid_ids,
+        M,
+        inter_dim,
+        model_dim,
+        blocks,
+        stream_ptr,
+    )
+
+    # --- Step 7: Quantize intermediate for Stage 2 ---
+    out1_fp32 = out1.to(torch.float32)
+    a2_fp8, scale_a2 = _pertoken_quant_fp8(out1_fp32, fp8_dtype)
+    a2_flat = a2_fp8.contiguous().view(-1)
+    scale_a2_1d = scale_a2.view(-1).contiguous()
+
+    # --- Step 8: Flatten w2 weights and scales ---
+    # w2: [E, model_dim, inter_dim] -> [E*model_dim, inter_dim] -> flat 1D
+    w2_flat = w2.contiguous().view(-1)
+
+    if w2_scale.dim() == 1:
+        # per-tensor [E]: broadcast to [E*model_dim]
+        scale_w2_1d = w2_scale.unsqueeze(1).expand(E, w2.shape[1]).contiguous().view(-1)
+    elif w2_scale.dim() == 3:
+        # per-channel [E, model_dim, 1]
+        scale_w2_1d = w2_scale.contiguous().view(-1)
+    elif w2_scale.dim() == 2:
+        scale_w2_1d = w2_scale.contiguous().view(-1)
+    else:
+        scale_w2_1d = w2_scale.contiguous().view(-1)
+
+    # --- Step 9: Stage 2 (GEMM2 with atomic accumulation) ---
+    out2 = torch.zeros((M, model_dim), device=device, dtype=torch.float16)
+
+    exe2(
+        out2.view(-1),
+        a2_flat,
+        w2_flat,
+        scale_a2_1d,
+        scale_w2_1d,
+        sorted_ids,
+        sorted_expert_ids,
+        sorted_weights.view(-1),
+        num_valid_ids,
+        M,
+        model_dim,
+        inter_dim,
+        blocks,
+        stream_ptr,
+    )
+
+    return out2.to(x.dtype)

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -42,6 +42,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_SILU_MUL_QUANT", "1"
     )
     == "1",
+    "ATOM_USE_FLYDSL_MOE": lambda: os.getenv("ATOM_USE_FLYDSL_MOE", "0") == "1",
 }
 
 

--- a/tests/test_flydsl_moe.py
+++ b/tests/test_flydsl_moe.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Tests for FlyDSL MOE backend (atom/model_ops/flydsl_moe.py).
+
+Test tiers:
+  1. Unit tests (CPU-only, no FlyDSL/AITER deps): sorting, quantization, detection
+  2. Integration tests (GPU + FlyDSL): full flydsl_fp8_moe pipeline
+
+Run:
+  # Unit tests only (no GPU needed):
+  python3 tests/test_flydsl_moe.py --unit
+
+  # Full GPU test (needs FlyDSL on PYTHONPATH + GPU):
+  ATOM_USE_FLYDSL_MOE=1 PYTHONPATH=/path/to/FlyDSL:$PYTHONPATH \
+    python3 tests/test_flydsl_moe.py --gpu
+"""
+
+import os
+import sys
+import argparse
+import torch
+
+# Ensure ATOM root is on path
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (CPU-only)
+# ---------------------------------------------------------------------------
+def test_detection_disabled():
+    """_has_flydsl_moe returns False when env var is disabled."""
+    import atom.model_ops.flydsl_moe as mod
+
+    # Reset cache
+    mod._flydsl_moe_available = None
+    old = os.environ.get("ATOM_USE_FLYDSL_MOE")
+    os.environ["ATOM_USE_FLYDSL_MOE"] = "0"
+    try:
+        assert mod._has_flydsl_moe() is False, "Should be False when disabled"
+    finally:
+        mod._flydsl_moe_available = None
+        if old is None:
+            os.environ.pop("ATOM_USE_FLYDSL_MOE", None)
+        else:
+            os.environ["ATOM_USE_FLYDSL_MOE"] = old
+    print("  PASS: test_detection_disabled")
+
+
+def test_sorting_basic():
+    """Test moe_sorting_torch_native produces correct shapes and encoding."""
+    from atom.model_ops.flydsl_moe import moe_sorting_torch_native
+
+    M, topk, E, block_size = 8, 2, 4, 4
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # Deterministic routing
+    torch.manual_seed(42)
+    topk_ids = torch.randint(0, E, (M, topk), device=device, dtype=torch.int32)
+    topk_weights = torch.rand(M, topk, device=device, dtype=torch.float32)
+
+    sorted_ids, sorted_weights, sorted_expert_ids, num_tokens_post_pad = (
+        moe_sorting_torch_native(topk_ids, topk_weights, E, block_size)
+    )
+
+    # Shape checks
+    assert sorted_ids.dtype == torch.int32
+    assert sorted_weights.dtype == torch.float32
+    assert sorted_expert_ids.dtype == torch.int32
+    assert num_tokens_post_pad.shape == (2,)
+    assert num_tokens_post_pad[1].item() == M, "num_tokens should be M"
+
+    total_padded = num_tokens_post_pad[0].item()
+    assert total_padded > 0
+    assert total_padded % block_size == 0, "total should be block-aligned"
+
+    # Verify packed encoding: (topk_slot << 24 | token_id)
+    init_val = (topk << 24) | M
+    for i in range(total_padded):
+        val = sorted_ids[i].item()
+        if val == init_val:
+            continue  # padding sentinel
+        token_id = val & 0xFFFFFF
+        topk_slot = (val >> 24) & 0xFF
+        assert 0 <= token_id < M, f"token_id={token_id} out of range"
+        assert 0 <= topk_slot < topk, f"topk_slot={topk_slot} out of range"
+
+    print("  PASS: test_sorting_basic")
+
+
+def test_sorting_all_same_expert():
+    """Edge case: all tokens routed to same expert."""
+    from atom.model_ops.flydsl_moe import moe_sorting_torch_native
+
+    M, topk, E, block_size = 16, 1, 8, 4
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    topk_ids = torch.zeros(M, topk, device=device, dtype=torch.int32)  # all expert 0
+    topk_weights = torch.ones(M, topk, device=device, dtype=torch.float32)
+
+    sorted_ids, sorted_weights, sorted_expert_ids, num_tokens_post_pad = (
+        moe_sorting_torch_native(topk_ids, topk_weights, E, block_size)
+    )
+
+    total_padded = num_tokens_post_pad[0].item()
+    expected_blocks = (M + block_size - 1) // block_size
+    expected_padded = expected_blocks * block_size
+    assert (
+        total_padded == expected_padded
+    ), f"Expected {expected_padded} padded tokens, got {total_padded}"
+
+    # All expert_ids should be 0 for the used blocks
+    for i in range(expected_blocks):
+        assert sorted_expert_ids[i].item() == 0
+
+    print("  PASS: test_sorting_all_same_expert")
+
+
+def test_pertoken_quant_fp8():
+    """Test per-token FP8 quantization correctness."""
+    from atom.model_ops.flydsl_moe import _pertoken_quant_fp8
+
+    if not hasattr(torch, "float8_e4m3fnuz"):
+        print("  SKIP: test_pertoken_quant_fp8 (torch version lacks fp8 support)")
+        return
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    fp8_dtype = torch.float8_e4m3fnuz
+
+    x = torch.randn(32, 128, device=device, dtype=torch.float32)
+    x_fp8, scale_1d = _pertoken_quant_fp8(x, fp8_dtype)
+
+    assert x_fp8.shape == x.shape
+    assert x_fp8.dtype == fp8_dtype
+    assert scale_1d.shape == (32,), f"Expected [32], got {scale_1d.shape}"
+    assert scale_1d.dtype == torch.float32
+
+    # Dequantize and check approximate reconstruction
+    x_deq = x_fp8.to(torch.float32) * scale_1d.unsqueeze(1)
+    rel_err = (x_deq - x).abs() / (x.abs() + 1e-6)
+    mean_err = rel_err.mean().item()
+    assert mean_err < 0.2, f"Mean relative error too high: {mean_err}"
+
+    print(f"  PASS: test_pertoken_quant_fp8 (mean_rel_err={mean_err:.4f})")
+
+
+def test_pertoken_quant_3d():
+    """Test per-token FP8 quantization with 3D input."""
+    from atom.model_ops.flydsl_moe import _pertoken_quant_fp8
+
+    if not hasattr(torch, "float8_e4m3fnuz"):
+        print("  SKIP: test_pertoken_quant_3d (torch version lacks fp8 support)")
+        return
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    fp8_dtype = torch.float8_e4m3fnuz
+
+    x = torch.randn(8, 2, 64, device=device, dtype=torch.float32)
+    x_fp8, scale_1d = _pertoken_quant_fp8(x, fp8_dtype)
+
+    assert x_fp8.shape == x.shape
+    assert scale_1d.shape == (16,), f"Expected [16], got {scale_1d.shape}"
+
+    print("  PASS: test_pertoken_quant_3d")
+
+
+def run_unit_tests():
+    print("=" * 60)
+    print("Unit tests (CPU/GPU, no FlyDSL dependency)")
+    print("=" * 60)
+    test_detection_disabled()
+    test_sorting_basic()
+    test_sorting_all_same_expert()
+    test_pertoken_quant_fp8()
+    test_pertoken_quant_3d()
+    print("\nAll unit tests passed!")
+
+
+# ---------------------------------------------------------------------------
+# GPU integration tests (requires FlyDSL + GPU)
+# ---------------------------------------------------------------------------
+def test_flydsl_fp8_moe_gpu():
+    """Full end-to-end test: flydsl_fp8_moe on random FP8 weights."""
+    from atom.model_ops.flydsl_moe import _has_flydsl_moe, flydsl_fp8_moe
+
+    if not _has_flydsl_moe():
+        print("  SKIP: FlyDSL MOE not available")
+        return
+
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+
+    # Model dimensions (small for testing)
+    M = 64  # tokens
+    model_dim = 256
+    inter_dim = 128
+    E = 4  # experts
+    topk = 2
+
+    fp8_dtype = torch.float8_e4m3fnuz
+
+    # Create random FP8 weights (preshuffled via aiter)
+    w13_fp32 = torch.randn(E, 2 * inter_dim, model_dim, device=device) * 0.1
+    w2_fp32 = torch.randn(E, model_dim, inter_dim, device=device) * 0.1
+
+    # Quantize weights to FP8
+    fp8_max = torch.finfo(fp8_dtype).max
+    w13_amax = w13_fp32.abs().amax(dim=-1, keepdim=True)
+    w13_scale_full = (w13_amax / fp8_max).clamp(min=1e-12)
+    w13 = (w13_fp32 / w13_scale_full).clamp(-fp8_max, fp8_max).to(fp8_dtype)
+
+    w2_amax = w2_fp32.abs().amax(dim=-1, keepdim=True)
+    w2_scale_full = (w2_amax / fp8_max).clamp(min=1e-12)
+    w2 = (w2_fp32 / w2_scale_full).clamp(-fp8_max, fp8_max).to(fp8_dtype)
+
+    # Per-tensor scales [E]
+    w13_scale = w13_scale_full.squeeze(-1).amax(dim=-1)  # [E]
+    w2_scale = w2_scale_full.squeeze(-1).amax(dim=-1)  # [E]
+
+    # Shuffle weights (FlyDSL expects preshuffled)
+    try:
+        from aiter.ops.shuffle import shuffle_weight
+
+        w13 = shuffle_weight(w13)
+        w2 = shuffle_weight(w2)
+    except ImportError:
+        print("  WARNING: aiter shuffle not available, using unshuffled weights")
+
+    # Input and routing
+    x = torch.randn(M, model_dim, device=device, dtype=torch.bfloat16)
+    scores = torch.randn(M, E, device=device)
+    topk_vals, topk_ids = torch.topk(scores, k=topk, dim=1)
+    topk_weights = torch.softmax(topk_vals, dim=1).to(torch.float32)
+
+    # Run FlyDSL MOE
+    out = flydsl_fp8_moe(
+        x=x,
+        w13=w13,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        w13_scale=w13_scale,
+        w2_scale=w2_scale,
+        top_k=topk,
+        block_quant=False,
+        quant_type=None,
+    )
+
+    assert out.shape == (M, model_dim), f"Expected ({M}, {model_dim}), got {out.shape}"
+    assert out.dtype == x.dtype
+    assert torch.isfinite(out).all(), "Output contains NaN/Inf"
+
+    print(
+        f"  PASS: test_flydsl_fp8_moe_gpu (output shape={out.shape}, "
+        f"mean={out.float().mean():.4f}, std={out.float().std():.4f})"
+    )
+
+
+def run_gpu_tests():
+    print("=" * 60)
+    print("GPU integration tests (requires FlyDSL + GPU)")
+    print("=" * 60)
+    if not torch.cuda.is_available():
+        print("SKIP: No GPU available")
+        return
+    test_flydsl_fp8_moe_gpu()
+    print("\nAll GPU tests passed!")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--unit", action="store_true", help="Run unit tests only")
+    parser.add_argument("--gpu", action="store_true", help="Run GPU integration tests")
+    args = parser.parse_args()
+
+    if not args.unit and not args.gpu:
+        args.unit = True  # default to unit tests
+
+    if args.unit:
+        run_unit_tests()
+    if args.gpu:
+        run_gpu_tests()


### PR DESCRIPTION
## Summary

- Adds **FlyDSL** as an opt-in MOE backend for FP8 MoE inference, controlled by `ATOM_USE_FLYDSL_MOE=1`
- Adds **Triton fallback** when CK MOE sorting is unavailable (e.g. AITER built with `ENABLE_CK=0`)
- Three-way dispatch priority: **CK/ASM > FlyDSL > Triton** for both `CompressedTensorsFp8MoEMethod` and `Fp8MoEMethod`

## Changes

### New files
- `atom/model_ops/flydsl_moe.py` — FlyDSL MOE backend wrapper
- `tests/test_flydsl_moe.py` — Unit tests + GPU integration test skeleton

### Modified files
- `atom/model_ops/moe.py` — Three-way dispatch, CK detection, Triton fallback
- `atom/utils/envs.py` — `ATOM_USE_FLYDSL_MOE` env var

## Usage

```bash
# FlyDSL backend (requires FlyDSL on PYTHONPATH)
ATOM_USE_FLYDSL_MOE=1 PYTHONPATH=/path/to/FlyDSL:$PYTHONPATH python3 -m atom.engine ...

# Triton fallback (automatic when CK unavailable and FlyDSL not enabled)
python3 -m atom.engine ...
```

## Test plan

- [x] Unit tests pass — `python3 tests/test_flydsl_moe.py --unit`
- [ ] GPU integration test with FlyDSL MOE kernels
- [ ] End-to-end model inference with `ATOM_USE_FLYDSL_MOE=1`