### PR TITLE
fix: resolve FlyDSL MLIR symlinks for Python 3.12 in Docker

### DIFF
--- a/docker/Dockerfile.clean
+++ b/docker/Dockerfile.clean
@@ -50,17 +50,28 @@ RUN --mount=type=bind,from=wheels,source=/,target=/mnt/wheels \
         filelock typing-extensions sympy networkx jinja2 fsspec numpy pillow \
     && pip3 install --break-system-packages \
         /tmp/wheels/mori-*.whl \
-        /tmp/wheels/flydsl-*.whl \
     && pip3 install --break-system-packages \
         /tmp/wheels/amd_aiter-*.whl \
     && rm -rf /tmp/wheels \
     && python3 -c "import torch; print(f'PyTorch {torch.__version__}, ROCm: {torch.version.hip}')" \
     && python3 -c "import triton; print(f'Triton {triton.__version__}')" \
     && python3 -c "import aiter; print('AITER OK')" \
-    && python3 -c "import flydsl; print('FlyDSL OK')" \
     && pip3 show mori && echo "MORI wheel installed OK"
 
-# ── 3. ATOM (from build context — pure Python, instant install) ──────
+# ── 3. FlyDSL source (kernels, tests — for dev/profiling) ────────────
+# The wheel installs the flydsl package, but having the source tree
+# gives access to kernels/ and tests/ for benchmarking and profiling.
+# The _mlir symlinks are pre-resolved in Dockerfile.wheels so editable
+# installs work without the MLIR source tree.
+RUN --mount=type=bind,from=wheels,source=/flydsl_src,target=/mnt/flydsl_src \
+    mkdir -p /app \
+    && cp -r /mnt/flydsl_src /app/FlyDSL \
+    && cd /app/FlyDSL \
+    && FLIR_REBUILD=0 pip3 install --break-system-packages -e . \
+    && python3 -c "import flydsl; print('FlyDSL editable OK')" \
+    && python3 -c "from kernels.softmax_kernel import build_softmax_module; print('FlyDSL kernels OK')"
+
+# ── 4. ATOM (from build context — pure Python, instant install) ──────
 COPY . /app/ATOM
 RUN cd /app/ATOM && pip3 install --break-system-packages -e . \
     && python3 -c "import atom; print('ATOM OK')"

--- a/docker/Dockerfile.wheels
+++ b/docker/Dockerfile.wheels
@@ -115,6 +115,22 @@ RUN cd /build/FlyDSL \
     && cp dist/flydsl-*.whl /wheels/ \
     && ls -lh /wheels/flydsl-*.whl
 
+# Dereference symlinks in _mlir so that editable installs work without
+# the MLIR source tree.  The build creates symlinks from the _mlir Python
+# files (ir.py, dialects/*.py, etc.) into /build/llvm-project/…, which
+# won't exist in the clean runtime image.
+RUN cd /build/FlyDSL \
+    && _mlir=".flir/build/python_packages/flydsl/_mlir" \
+    && tmp_resolved="/tmp/_mlir_resolved" \
+    && cp -rL "$_mlir" "$tmp_resolved" \
+    && rm -rf "$_mlir" \
+    && mv "$tmp_resolved" "$_mlir"
+
+# Export the FlyDSL source tree (with resolved _mlir, kernels, tests)
+# to /flydsl_src/ so Dockerfile.clean can optionally COPY it for dev use.
+RUN cp -r /build/FlyDSL /flydsl_src \
+    && rm -rf /flydsl_src/.git
+
 # ── 7. Build MORI wheel ─────────────────────────────────────────────
 RUN apt-get update && apt-get install -y --no-install-recommends \
         openmpi-bin libopenmpi-dev cython3 libdw1 \


### PR DESCRIPTION
## Summary
- Fix FlyDSL import failure in Docker containers caused by broken MLIR symlinks
- The FlyDSL build creates symlinks from `_mlir` Python files (ir.py, dialects/*.py) into the MLIR source tree, which doesn't exist in runtime images
- **Dockerfile.wheels**: dereference symlinks after wheel build and export source tree to `/flydsl_src/`
- **Dockerfile.clean**: install FlyDSL as editable from exported source (includes kernels/ and tests/ for profiling)

## Root Cause
The `.flir/build/python_packages/flydsl/_mlir/` directory contains symlinks like:
```
ir.py -> /build/llvm-project/mlir_install/src/python/MLIRPythonSources.Core.Python/ir.py
```
These resolve inside the wheels builder stage but break in the clean runtime image where LLVM source is absent, causing:
```
ImportError: cannot import name 'ir' from '_mlir' (unknown location)
```

## Test plan
- [x] Rebuilt `atom:wheels` — FlyDSL symlinks dereferenced, `/flydsl_src/` exported
- [x] Rebuilt `atom:clean-v3` — FlyDSL editable install works with cpython-312 .so files
- [x] Verified `import flydsl` and `from _mlir import ir` succeed
- [x] Verified FlyDSL softmax kernel compiles and runs correctly on MI300X GPU