### PR TITLE
Remove dead code in sampler.py

### DIFF
--- a/atom/model_ops/sampler.py
+++ b/atom/model_ops/sampler.py
@@ -3,8 +3,6 @@
 
 import torch
 from aiter import mixed_sample_outer_exponential
-from aiter.ops.triton.softmax import softmax
-from aiter.ops.triton.topk import topk
 from torch import nn
 
 
@@ -31,21 +29,3 @@ class Sampler(nn.Module):
             sampled_tokens, logits, exponential, temperatures, eps=self.eps
         )
         return sampled_tokens
-        logits = logits.float()
-        return torch.where(
-            temperatures == 0, self.greedy_sample(logits), self.random_sample(logits)
-        ).to(torch.int)
-
-    def greedy_sample(
-        self, logits: torch.Tensor  # (token_num, vocab_size)
-    ) -> torch.Tensor:  # (token_num,)
-        _, sampled_tokens = topk(logits, 1)
-        return sampled_tokens.view(-1)
-
-    def random_sample(
-        self, logits: torch.Tensor  # (token_num, vocab_size)
-    ) -> torch.Tensor:  # (token_num,)
-        probs = softmax(logits)
-        logits = probs.div_(torch.empty_like(probs).exponential_(1) + self.eps)
-        _, sampled_tokens = topk(logits, 1)
-        return sampled_tokens.view(-1)


### PR DESCRIPTION
## Summary
- Remove unreachable code after `return sampled_tokens` on line 33
- Remove unused `greedy_sample` and `random_sample` methods
- Remove unused imports (`softmax`, `topk`) that were only used by the dead methods

The `mixed_sample_outer_exponential` call already handles both greedy (temp=0) and random sampling in a single fused kernel.

## Test plan
- [x] Existing ATOM E2E benchmarks (GPT-OSS, DeepSeek R1) use this sampler — no behavior change since the removed code was unreachable