### PR TITLE
Add CK-free fallback for fused QKNorm+RoPE+Cache

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
+import logging
 from typing import Optional
 
 import aiter
@@ -14,6 +15,8 @@ from atom.utils.forward_context import ForwardContext, get_forward_context
 from torch import nn
 
 from .attention_mla import MLAModules
+
+logger = logging.getLogger("atom")
 
 from atom.plugin.prepare import is_plugin_mode, is_vllm
 from atom.plugin.attention_mha import PagedAttentionImplDecoratorForPluginMode
@@ -122,38 +125,58 @@ class PagedAttentionImpl(nn.Module):
         use_triton_attn = self.sliding_window != -1 or self.head_dim != 128
         self.use_triton_attn = use_triton_attn
 
+        _fused_ok = False
         if (
             self.rotary_emb is not None
             and self.q_norm is not None
             and self.k_norm is not None
         ):
-            fused_qk_norm_rope_cache_quant_shuffle(
-                qkv,
-                num_heads_q=self.num_heads,
-                num_heads_k=self.num_kv_heads,
-                num_heads_v=self.num_kv_heads,
-                head_dim=self.head_dim,
-                eps=self.q_norm.eps,
-                qw=self.q_norm.weight,
-                kw=self.k_norm.weight,
-                cos_sin_cache=self.rotary_emb.cos_sin_cache,
-                is_neox_style=self.rotary_emb.is_neox_style,
-                pos_ids=position,
-                k_cache=k_cache,
-                v_cache=v_cache,
-                slot_mapping=attn_metadata.slot_mapping,
-                kv_cache_dtype=(
-                    "auto" if self.kv_cache_dtype == "bf16" else self.kv_cache_dtype
-                ),
-                k_scale=k_scale,
-                v_scale=v_scale,
-            )
+            qkv_backup = qkv.clone()
+            try:
+                fused_qk_norm_rope_cache_quant_shuffle(
+                    qkv,
+                    num_heads_q=self.num_heads,
+                    num_heads_k=self.num_kv_heads,
+                    num_heads_v=self.num_kv_heads,
+                    head_dim=self.head_dim,
+                    eps=self.q_norm.eps,
+                    qw=self.q_norm.weight,
+                    kw=self.k_norm.weight,
+                    cos_sin_cache=self.rotary_emb.cos_sin_cache,
+                    is_neox_style=self.rotary_emb.is_neox_style,
+                    pos_ids=position,
+                    k_cache=k_cache,
+                    v_cache=v_cache,
+                    slot_mapping=attn_metadata.slot_mapping,
+                    kv_cache_dtype=(
+                        "auto" if self.kv_cache_dtype == "bf16" else self.kv_cache_dtype
+                    ),
+                    k_scale=k_scale,
+                    v_scale=v_scale,
+                )
 
-            qkv = qkv.view(qkv.shape[0], -1, self.head_dim)
-            q, k, v = qkv.split(
-                [self.num_heads, self.num_kv_heads, self.num_kv_heads], dim=1
-            )
-        elif use_triton_attn and self.rotary_emb is not None:
+                qkv = qkv.view(qkv.shape[0], -1, self.head_dim)
+                q, k, v = qkv.split(
+                    [self.num_heads, self.num_kv_heads, self.num_kv_heads], dim=1
+                )
+                _fused_ok = True
+            except Exception as e:
+                if not getattr(PagedAttentionImpl, "_fused_rope_warned", False):
+                    logger.warning(
+                        "fused_qk_norm_rope_cache_quant_shuffle failed (%s), "
+                        "falling back to non-fused path",
+                        e,
+                    )
+                    PagedAttentionImpl._fused_rope_warned = True
+                qkv.copy_(qkv_backup)
+            del qkv_backup
+
+        if (
+            not _fused_ok
+            and use_triton_attn
+            and self.rotary_emb is not None
+            and self.q_norm is None
+        ):
             k_scale = v_scale = self.kv_scale
 
             q, k, k_cache, v_cache = fused_qk_rope_reshape_and_cache(
@@ -176,7 +199,7 @@ class PagedAttentionImpl(nn.Module):
                 k_out=k,
                 output_zeros=False,
             )
-        else:
+        elif not _fused_ok:
             # for asm paged attention
             asm_layout = True
             if use_triton_attn:


### PR DESCRIPTION
## Summary
- Wraps `fused_qk_norm_rope_cache_quant_shuffle` in `attention_mha.py:rope_cache()` with try-except
- On CK-free builds where the HIP fused kernel is unavailable, gracefully falls through to the existing non-fused Triton path (rotary_emb + q/k_norm + reshape_and_cache)
- `qkv.clone()` backup before fused kernel call, restored on failure (protects against partial in-place writes)
- Log-once warning via class attribute to avoid log spam on hot path
- `q_norm is None` guard on middle path preserves original `elif` invariant

## Related
- Companion to upstream PR #278 (CK-free Docker builds)

## Test Results

| # | Test | Result |
|---|------|--------|
| 1 | Import: `from atom.model_ops.attention_mha import PagedAttentionImpl` | **PASS** |
| 2 | Mock: fused kernel raises → fallback executes (rotary_emb, q_norm, k_norm all called, qkv restored, log-once) | **PASS** |
| 3 | E2E: Qwen3-0.6B with fused kernel disabled | **BLOCKED** (separate FMHA CK-free JIT issue) |
| 4 | Numerical: fused vs non-fused cosine similarity | **BLOCKED** (same FMHA issue) |

## Known Limitation
E2E tests are blocked by a **separate AITER-side issue**: `module_fmha_v3_varlen_fwd` JIT compilation fails in CK-free builds because the ASM attention kernels still depend on CK-Tile headers (`fmha_fwd.hpp`). Our `rope_cache` fallback works correctly through model load + warmup (logs confirm individual `module_rope_pos_fwd` and `module_cache` loaded successfully).

**Shengnan's team is working on removing the CK header dependency from ASM attention kernels in AITER.** Once that lands, the full CK-free E2E path (this PR + FMHA fix) will be unblocked.