### PR TITLE
[W4.1] DSV4ForwardBatch metadata scaffold (Path 3 / issue #37)

### DIFF
--- a/atom/utils/dsv4_forward_batch.py
+++ b/atom/utils/dsv4_forward_batch.py
@@ -70,9 +70,14 @@ class DSV4ForwardBatch:
         prefix sum, 0-prefixed. Equivalent to ATOM's existing
         `attn_metadata.cu_seqlens_q`.
     req_pool_indices: `[num_seqs]` long tensor — opaque per-seq id stable
-        across steps; W4.2 wires this to the engine KV-pool slot assignment.
-        For W4.1 we accept any monotonic int (ATOM's existing
-        `block_tables[:, 0]` first-block-id is a valid placeholder).
+        across steps. **W4.1 PLACEHOLDER**: `from_attn_metadata()` populates
+        this with `block_tables[:, 0]` (first physical block id). This is
+        NOT stable-unique under prefix caching / block reuse: two
+        prefix-sharing seqs can share a first block. Do not depend on
+        uniqueness — call `assert_pool_slot_unique()` if you need that
+        guarantee at the call site. W4.2 replaces the adapter with the
+        engine KV-pool's true slot allocator, which guarantees a stable
+        unique id per active seq regardless of prefix-cache state.
     out_cache_loc: `[num_tokens]` long tensor — absolute slot in the engine
         KV pool where each token's KV should be written. W4.2 fills this
         with `req_pool_indices[seq] * ring_size + (positions[t] %
@@ -180,6 +185,29 @@ class DSV4ForwardBatch:
     def is_prefill(self) -> bool:
         return self.forward_mode == DSV4ForwardMode.PREFILL
 
+    def assert_pool_slot_unique(self) -> None:
+        """Runtime check: `req_pool_indices` has no duplicates.
+
+        W4.1 callers depending on per-seq isolation (e.g., per-seq
+        kv_cache row indexing) MUST call this before using
+        `req_pool_indices` as a unique seq tag — the W4.1 placeholder
+        adapter (`from_attn_metadata`) sets it to `block_tables[:, 0]`
+        which can collide under prefix caching. W4.2 makes this
+        unconditional, but until then this is the explicit gate.
+        """
+        if self.req_pool_indices.numel() == 0:
+            return
+        unique = torch.unique(self.req_pool_indices)
+        if unique.numel() != self.req_pool_indices.numel():
+            raise ValueError(
+                "req_pool_indices is not unique — likely a prefix-cache "
+                "first-block collision (W4.1 placeholder limitation). "
+                "Got "
+                f"{self.req_pool_indices.tolist()}. Wait for W4.2 "
+                "engine KV-pool slot allocator to land before relying on "
+                "uniqueness, or disable prefix caching for this run."
+            )
+
     @classmethod
     def from_attn_metadata(
         cls,
@@ -195,36 +223,40 @@ class DSV4ForwardBatch:
         owned pool and out_cache_loc, this adapter is upgraded to
         `from_engine_state()` (W4.4).
 
-        Args:
-            attn_metadata: ATOM `AttentionMetaData` instance with
-                cu_seqlens_q, block_tables, context_lens populated.
-            positions: per-token positions tensor.
+        ATOM normally builds attn_metadata tensors on CUDA, but a few
+        paths (warmup, CPU-fallback unit tests) construct them on CPU
+        while `positions` lands on the model's GPU device. Normalize
+        ALL fields to `positions.device` here so __post_init__'s
+        device-uniformity invariant holds regardless of where the
+        upstream tensors started.
         """
-        cu = attn_metadata.cu_seqlens_q.to(torch.long)
+        device = positions.device
+        cu = attn_metadata.cu_seqlens_q.to(torch.long).to(device)
         num_seqs = cu.numel() - 1
-        # extend_seq_lens = cu[1:] - cu[:-1]
+        # extend_seq_lens computed on the unified target device
         extend_seq_lens = cu[1:] - cu[:-1]
 
         # context_lens may not be populated in pure-prefill warmup paths;
         # fall back to extend_seq_lens (no prior KV).
         context_lens = getattr(attn_metadata, "context_lens", None)
         if context_lens is not None and context_lens.numel() == num_seqs:
-            seq_lens = context_lens.to(torch.long).to(positions.device) + extend_seq_lens
+            seq_lens = context_lens.to(torch.long).to(device) + extend_seq_lens
         else:
             seq_lens = extend_seq_lens.clone()
 
-        # req_pool_indices: use block_tables[:, 0] as a stable per-seq id.
-        # In W4.2 this becomes the engine-pool slot index directly.
+        # req_pool_indices: see field docstring — W4.1 placeholder fills
+        # with block_tables[:, 0]; NOT stable-unique under prefix caching.
+        # Call assert_pool_slot_unique() if uniqueness is required.
         block_tables = getattr(attn_metadata, "block_tables", None)
         if (
             block_tables is not None
             and block_tables.dim() == 2
             and block_tables.shape[0] == num_seqs
         ):
-            req_pool_indices = block_tables[:, 0].to(torch.long).to(positions.device)
+            req_pool_indices = block_tables[:, 0].to(torch.long).to(device)
         else:
             req_pool_indices = torch.arange(
-                num_seqs, dtype=torch.long, device=positions.device
+                num_seqs, dtype=torch.long, device=device
             )
 
         # forward_mode: if any seq has extend > 1, it's prefill (mixed batch
@@ -237,12 +269,16 @@ class DSV4ForwardBatch:
         else:
             mode = DSV4ForwardMode.DECODE
 
+        # block_tables is kept as a pass-through reference; if it lives
+        # on a different device that's fine (model layers will move it
+        # when consumed in W4.3+). Only the metadata tensors that
+        # __post_init__ asserts on are guaranteed to share device.
         return cls(
             forward_mode=mode,
             positions=positions.to(torch.long),
-            seq_lens=seq_lens.to(torch.long),
-            extend_seq_lens=extend_seq_lens.to(torch.long),
-            cu_seqlens_q=cu.to(torch.long),
+            seq_lens=seq_lens,
+            extend_seq_lens=extend_seq_lens,
+            cu_seqlens_q=cu,
             req_pool_indices=req_pool_indices,
             block_tables=block_tables,
         )

--- a/atom/utils/dsv4_forward_batch.py
+++ b/atom/utils/dsv4_forward_batch.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""DSV4 ForwardBatch metadata (Path 3 / W4.1 — issue #37).
+
+This module defines `DSV4ForwardBatch`, the per-step metadata object the
+DSV4 model layers will consume in the SGLang/vLLM-isomorphic refactor
+(see issue #37 for the architectural rationale and PR-split plan).
+
+W4.1 SCOPE: structure only. We define the dataclass, validate field
+shapes/dtypes/devices, and provide a `from_attn_metadata()` adapter that
+constructs a DSV4ForwardBatch from ATOM's existing
+`forward_context.attn_metadata` so the runtime can be plumbed through
+later stages without changing model behavior in this PR.
+
+W4.2-W4.6 will progressively wire this object into:
+- engine-owned KV/state pools (W4.2)
+- Compressor/Indexer state owned by pools, not nn.Module register_buffer (W4.4)
+- DeepseekV4Attention.forward consumption (W4.3)
+- correctness validation conc=4 (W4.5)
+- perf optimization: in-graph metadata, fused kernels (W4.6)
+
+Reference design: SGLang `python/sglang/srt/models/deepseek_v4.py:819`
+(`MQALayer.forward(x, positions, forward_batch)`) and vLLM
+`vllm/model_executor/layers/deepseek_v4_attention.py:650`
+(`forward(self, q, kv, positions, output)`).
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import torch
+
+
+class DSV4ForwardMode(enum.Enum):
+    """High-level dispatch mode for one model step."""
+
+    PREFILL = "prefill"
+    """Mixed or pure prefill batch — at least one seq has > 1 token."""
+    DECODE = "decode"
+    """All seqs have exactly 1 token (lockstep decode)."""
+    IDLE = "idle"
+    """Warmup / dummy step. No real seqs to attend to."""
+
+
+@dataclass
+class DSV4ForwardBatch:
+    """Per-step metadata for a DSV4 forward pass.
+
+    All tensor fields are 1-D unless documented otherwise. Validation in
+    `__post_init__` checks dtype/device/shape consistency so model layers
+    can rely on invariants without re-checking.
+
+    Fields
+    ------
+    forward_mode: which dispatch path to take (see `DSV4ForwardMode`).
+    positions: `[num_tokens]` long tensor of absolute positions per token.
+        For prefill, each seq's positions are sequential starting at the
+        seq's previous KV length (0 for fresh requests). For decode, each
+        token's position equals `seq_lens[seq_idx_of_token] - 1` (token
+        is being generated AT that position).
+    seq_lens: `[num_seqs]` long tensor — total length each seq has after
+        this step (= context length + new tokens generated this step).
+    extend_seq_lens: `[num_seqs]` long tensor — number of NEW tokens this
+        seq is processing this step. For prefill = seq_len; for decode = 1.
+    cu_seqlens_q: `[num_seqs + 1]` int32 tensor — cumulative `extend_seq_lens`
+        prefix sum, 0-prefixed. Equivalent to ATOM's existing
+        `attn_metadata.cu_seqlens_q`.
+    req_pool_indices: `[num_seqs]` long tensor — opaque per-seq id stable
+        across steps; W4.2 wires this to the engine KV-pool slot assignment.
+        For W4.1 we accept any monotonic int (ATOM's existing
+        `block_tables[:, 0]` first-block-id is a valid placeholder).
+    out_cache_loc: `[num_tokens]` long tensor — absolute slot in the engine
+        KV pool where each token's KV should be written. W4.2 fills this
+        with `req_pool_indices[seq] * ring_size + (positions[t] %
+        ring_size)`. W4.1 leaves it None (allocators not wired yet).
+    block_tables: pass-through reference to ATOM's existing
+        `attn_metadata.block_tables` (`[num_seqs, max_blocks_per_seq]`).
+        Kept here so a single ForwardBatch carries everything the model
+        layer needs without re-fetching from the global forward_context.
+    """
+
+    forward_mode: DSV4ForwardMode
+    positions: torch.Tensor
+    seq_lens: torch.Tensor
+    extend_seq_lens: torch.Tensor
+    cu_seqlens_q: torch.Tensor
+    req_pool_indices: torch.Tensor
+
+    # Optional in W4.1 (will become required in W4.2 once pools are wired).
+    out_cache_loc: Optional[torch.Tensor] = None
+    block_tables: Optional[torch.Tensor] = None
+
+    # Reserved for W4.2: link to the engine-owned DSV4 KV/state pool.
+    # Kept Optional + Any to avoid a hard import on the (not-yet-existing)
+    # dsv4_pool module.
+    kv_pool: Optional[Any] = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        # ---- shape invariants ----
+        assert self.positions.dim() == 1, (
+            f"positions must be 1-D [num_tokens], got shape {tuple(self.positions.shape)}"
+        )
+        assert self.seq_lens.dim() == 1, "seq_lens must be 1-D [num_seqs]"
+        assert self.extend_seq_lens.dim() == 1, "extend_seq_lens must be 1-D [num_seqs]"
+        assert self.cu_seqlens_q.dim() == 1, "cu_seqlens_q must be 1-D [num_seqs + 1]"
+        assert self.req_pool_indices.dim() == 1, (
+            "req_pool_indices must be 1-D [num_seqs]"
+        )
+
+        num_seqs = self.seq_lens.numel()
+        num_tokens = self.positions.numel()
+        assert self.extend_seq_lens.numel() == num_seqs, (
+            f"extend_seq_lens.numel()={self.extend_seq_lens.numel()} "
+            f"!= num_seqs={num_seqs}"
+        )
+        assert self.cu_seqlens_q.numel() == num_seqs + 1, (
+            f"cu_seqlens_q.numel()={self.cu_seqlens_q.numel()} "
+            f"!= num_seqs+1={num_seqs + 1}"
+        )
+        assert self.req_pool_indices.numel() == num_seqs, (
+            f"req_pool_indices.numel()={self.req_pool_indices.numel()} "
+            f"!= num_seqs={num_seqs}"
+        )
+        # cu_seqlens_q's last entry must equal total tokens
+        if num_seqs > 0:
+            tail = int(self.cu_seqlens_q[-1].item())
+            assert tail == num_tokens, (
+                f"cu_seqlens_q[-1]={tail} != num_tokens={num_tokens}"
+            )
+
+        # ---- dtype invariants ----
+        assert self.positions.dtype in (torch.long, torch.int32, torch.int64), (
+            f"positions must be int dtype, got {self.positions.dtype}"
+        )
+        assert self.seq_lens.dtype in (torch.long, torch.int32, torch.int64)
+        assert self.extend_seq_lens.dtype in (torch.long, torch.int32, torch.int64)
+        assert self.cu_seqlens_q.dtype in (torch.long, torch.int32, torch.int64)
+        assert self.req_pool_indices.dtype in (torch.long, torch.int32, torch.int64)
+
+        # ---- device invariants ----
+        device = self.positions.device
+        for fname in ("seq_lens", "extend_seq_lens", "cu_seqlens_q", "req_pool_indices"):
+            t = getattr(self, fname)
+            assert t.device == device, (
+                f"{fname}.device={t.device} != positions.device={device}"
+            )
+
+        # ---- forward_mode consistency ----
+        if self.forward_mode == DSV4ForwardMode.DECODE and num_seqs > 0:
+            # In decode mode, every seq emits exactly 1 new token.
+            ext = self.extend_seq_lens
+            assert bool(torch.all(ext == 1).item()), (
+                f"DECODE mode requires extend_seq_lens == 1 for all seqs, got {ext.tolist()}"
+            )
+        elif self.forward_mode == DSV4ForwardMode.PREFILL and num_seqs > 0:
+            # In prefill mode, at least one seq has > 1 new token.
+            ext = self.extend_seq_lens
+            assert bool(torch.any(ext > 1).item()), (
+                f"PREFILL mode requires at least one seq with extend_seq_len > 1, "
+                f"got {ext.tolist()}"
+            )
+
+    @property
+    def num_seqs(self) -> int:
+        return self.seq_lens.numel()
+
+    @property
+    def num_tokens(self) -> int:
+        return self.positions.numel()
+
+    @property
+    def is_decode(self) -> bool:
+        return self.forward_mode == DSV4ForwardMode.DECODE
+
+    @property
+    def is_prefill(self) -> bool:
+        return self.forward_mode == DSV4ForwardMode.PREFILL
+
+    @classmethod
+    def from_attn_metadata(
+        cls,
+        attn_metadata: Any,
+        positions: torch.Tensor,
+    ) -> "DSV4ForwardBatch":
+        """Adapter: construct DSV4ForwardBatch from ATOM's
+        `forward_context.attn_metadata` + positions tensor.
+
+        Used during W4.1-W4.3 transition where the runtime still produces
+        ATOM's standard AttentionMetaData but the DSV4 model is being
+        migrated to consume DSV4ForwardBatch. Once W4.2 wires the engine-
+        owned pool and out_cache_loc, this adapter is upgraded to
+        `from_engine_state()` (W4.4).
+
+        Args:
+            attn_metadata: ATOM `AttentionMetaData` instance with
+                cu_seqlens_q, block_tables, context_lens populated.
+            positions: per-token positions tensor.
+        """
+        cu = attn_metadata.cu_seqlens_q.to(torch.long)
+        num_seqs = cu.numel() - 1
+        # extend_seq_lens = cu[1:] - cu[:-1]
+        extend_seq_lens = cu[1:] - cu[:-1]
+
+        # context_lens may not be populated in pure-prefill warmup paths;
+        # fall back to extend_seq_lens (no prior KV).
+        context_lens = getattr(attn_metadata, "context_lens", None)
+        if context_lens is not None and context_lens.numel() == num_seqs:
+            seq_lens = context_lens.to(torch.long).to(positions.device) + extend_seq_lens
+        else:
+            seq_lens = extend_seq_lens.clone()
+
+        # req_pool_indices: use block_tables[:, 0] as a stable per-seq id.
+        # In W4.2 this becomes the engine-pool slot index directly.
+        block_tables = getattr(attn_metadata, "block_tables", None)
+        if (
+            block_tables is not None
+            and block_tables.dim() == 2
+            and block_tables.shape[0] == num_seqs
+        ):
+            req_pool_indices = block_tables[:, 0].to(torch.long).to(positions.device)
+        else:
+            req_pool_indices = torch.arange(
+                num_seqs, dtype=torch.long, device=positions.device
+            )
+
+        # forward_mode: if any seq has extend > 1, it's prefill (mixed batch
+        # is also classified as PREFILL — the runtime will decide internal
+        # dispatch via cu_seqlens_q). Otherwise decode. Empty batch = idle.
+        if num_seqs == 0:
+            mode = DSV4ForwardMode.IDLE
+        elif bool(torch.any(extend_seq_lens > 1).item()):
+            mode = DSV4ForwardMode.PREFILL
+        else:
+            mode = DSV4ForwardMode.DECODE
+
+        return cls(
+            forward_mode=mode,
+            positions=positions.to(torch.long),
+            seq_lens=seq_lens.to(torch.long),
+            extend_seq_lens=extend_seq_lens.to(torch.long),
+            cu_seqlens_q=cu.to(torch.long),
+            req_pool_indices=req_pool_indices,
+            block_tables=block_tables,
+        )

--- a/atom/utils/dsv4_forward_batch.py
+++ b/atom/utils/dsv4_forward_batch.py
@@ -106,15 +106,15 @@ class DSV4ForwardBatch:
 
     def __post_init__(self) -> None:
         # ---- shape invariants ----
-        assert self.positions.dim() == 1, (
-            f"positions must be 1-D [num_tokens], got shape {tuple(self.positions.shape)}"
-        )
+        assert (
+            self.positions.dim() == 1
+        ), f"positions must be 1-D [num_tokens], got shape {tuple(self.positions.shape)}"
         assert self.seq_lens.dim() == 1, "seq_lens must be 1-D [num_seqs]"
         assert self.extend_seq_lens.dim() == 1, "extend_seq_lens must be 1-D [num_seqs]"
         assert self.cu_seqlens_q.dim() == 1, "cu_seqlens_q must be 1-D [num_seqs + 1]"
-        assert self.req_pool_indices.dim() == 1, (
-            "req_pool_indices must be 1-D [num_seqs]"
-        )
+        assert (
+            self.req_pool_indices.dim() == 1
+        ), "req_pool_indices must be 1-D [num_seqs]"
 
         num_seqs = self.seq_lens.numel()
         num_tokens = self.positions.numel()
@@ -133,14 +133,16 @@ class DSV4ForwardBatch:
         # cu_seqlens_q's last entry must equal total tokens
         if num_seqs > 0:
             tail = int(self.cu_seqlens_q[-1].item())
-            assert tail == num_tokens, (
-                f"cu_seqlens_q[-1]={tail} != num_tokens={num_tokens}"
-            )
+            assert (
+                tail == num_tokens
+            ), f"cu_seqlens_q[-1]={tail} != num_tokens={num_tokens}"
 
         # ---- dtype invariants ----
-        assert self.positions.dtype in (torch.long, torch.int32, torch.int64), (
-            f"positions must be int dtype, got {self.positions.dtype}"
-        )
+        assert self.positions.dtype in (
+            torch.long,
+            torch.int32,
+            torch.int64,
+        ), f"positions must be int dtype, got {self.positions.dtype}"
         assert self.seq_lens.dtype in (torch.long, torch.int32, torch.int64)
         assert self.extend_seq_lens.dtype in (torch.long, torch.int32, torch.int64)
         assert self.cu_seqlens_q.dtype in (torch.long, torch.int32, torch.int64)
@@ -148,19 +150,24 @@ class DSV4ForwardBatch:
 
         # ---- device invariants ----
         device = self.positions.device
-        for fname in ("seq_lens", "extend_seq_lens", "cu_seqlens_q", "req_pool_indices"):
+        for fname in (
+            "seq_lens",
+            "extend_seq_lens",
+            "cu_seqlens_q",
+            "req_pool_indices",
+        ):
             t = getattr(self, fname)
-            assert t.device == device, (
-                f"{fname}.device={t.device} != positions.device={device}"
-            )
+            assert (
+                t.device == device
+            ), f"{fname}.device={t.device} != positions.device={device}"
 
         # ---- forward_mode consistency ----
         if self.forward_mode == DSV4ForwardMode.DECODE and num_seqs > 0:
             # In decode mode, every seq emits exactly 1 new token.
             ext = self.extend_seq_lens
-            assert bool(torch.all(ext == 1).item()), (
-                f"DECODE mode requires extend_seq_lens == 1 for all seqs, got {ext.tolist()}"
-            )
+            assert bool(
+                torch.all(ext == 1).item()
+            ), f"DECODE mode requires extend_seq_lens == 1 for all seqs, got {ext.tolist()}"
         elif self.forward_mode == DSV4ForwardMode.PREFILL and num_seqs > 0:
             # In prefill mode, at least one seq has > 1 new token.
             ext = self.extend_seq_lens
@@ -255,9 +262,7 @@ class DSV4ForwardBatch:
         ):
             req_pool_indices = block_tables[:, 0].to(torch.long).to(device)
         else:
-            req_pool_indices = torch.arange(
-                num_seqs, dtype=torch.long, device=device
-            )
+            req_pool_indices = torch.arange(num_seqs, dtype=torch.long, device=device)
 
         # forward_mode: if any seq has extend > 1, it's prefill (mixed batch
         # is also classified as PREFILL — the runtime will decide internal

--- a/tests/test_dsv4_forward_batch.py
+++ b/tests/test_dsv4_forward_batch.py
@@ -110,7 +110,9 @@ class TestInvariants:
                 forward_mode=DSV4ForwardMode.DECODE,
                 positions=torch.tensor([12, 13, 14], dtype=torch.long),
                 seq_lens=torch.tensor([13, 14], dtype=torch.long),
-                extend_seq_lens=torch.tensor([1, 2], dtype=torch.long),  # second seq has 2
+                extend_seq_lens=torch.tensor(
+                    [1, 2], dtype=torch.long
+                ),  # second seq has 2
                 cu_seqlens_q=torch.tensor([0, 1, 3], dtype=torch.long),
                 req_pool_indices=torch.tensor([0, 1], dtype=torch.long),
             )
@@ -196,7 +198,9 @@ class TestFromAttnMetadata:
 
     def test_int32_cu_normalized_to_long(self):
         cu = torch.tensor([0, 3], dtype=torch.int32)
-        attn_meta = SimpleNamespace(cu_seqlens_q=cu, block_tables=None, context_lens=None)
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=None, context_lens=None
+        )
         positions = torch.tensor([0, 1, 2], dtype=torch.int32)
         fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
         assert fb.positions.dtype == torch.long
@@ -211,7 +215,9 @@ class TestFromAttnMetadata:
         must move ALL metadata tensors to positions.device.
         """
         cu = torch.tensor([0, 12, 25], dtype=torch.long, device="cpu")
-        block_tables = torch.tensor([[10, 11], [20, 21]], dtype=torch.long, device="cpu")
+        block_tables = torch.tensor(
+            [[10, 11], [20, 21]], dtype=torch.long, device="cpu"
+        )
         context_lens = torch.zeros(2, dtype=torch.long, device="cpu")
         attn_meta = SimpleNamespace(
             cu_seqlens_q=cu, block_tables=block_tables, context_lens=context_lens
@@ -238,15 +244,18 @@ class TestFromAttnMetadata:
         attn_meta = SimpleNamespace(
             cu_seqlens_q=cu, block_tables=block_tables, context_lens=None
         )
-        positions = torch.tensor(
-            list(range(12)) + list(range(13)), dtype=torch.long
-        )
+        positions = torch.tensor(list(range(12)) + list(range(13)), dtype=torch.long)
         fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
         ref_dev = positions.device
-        for fname in ("cu_seqlens_q", "extend_seq_lens", "seq_lens", "req_pool_indices"):
-            assert getattr(fb, fname).device == ref_dev, (
-                f"{fname} on {getattr(fb, fname).device}, expected {ref_dev}"
-            )
+        for fname in (
+            "cu_seqlens_q",
+            "extend_seq_lens",
+            "seq_lens",
+            "req_pool_indices",
+        ):
+            assert (
+                getattr(fb, fname).device == ref_dev
+            ), f"{fname} on {getattr(fb, fname).device}, expected {ref_dev}"
 
 
 class TestPoolSlotUniqueness:

--- a/tests/test_dsv4_forward_batch.py
+++ b/tests/test_dsv4_forward_batch.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: MIT
+"""W4.1 (issue #37 Path 3): DSV4ForwardBatch metadata structure tests.
+
+Validates the dataclass invariants and the `from_attn_metadata()`
+adapter without touching any model layer (W4.1 scope).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from atom.utils.dsv4_forward_batch import DSV4ForwardBatch, DSV4ForwardMode
+
+
+def _make_basic_prefill():
+    """4 seqs of length 12/13/15/12 packed (52 total tokens)."""
+    extend = [12, 13, 15, 12]
+    cu = [0, 12, 25, 40, 52]
+    positions = []
+    for n in extend:
+        positions.extend(range(n))
+    return DSV4ForwardBatch(
+        forward_mode=DSV4ForwardMode.PREFILL,
+        positions=torch.tensor(positions, dtype=torch.long),
+        seq_lens=torch.tensor(extend, dtype=torch.long),
+        extend_seq_lens=torch.tensor(extend, dtype=torch.long),
+        cu_seqlens_q=torch.tensor(cu, dtype=torch.long),
+        req_pool_indices=torch.tensor([10, 20, 30, 40], dtype=torch.long),
+    )
+
+
+def _make_basic_decode():
+    """4 seqs in decode, each generating 1 new token at position 12/13/15/12."""
+    return DSV4ForwardBatch(
+        forward_mode=DSV4ForwardMode.DECODE,
+        positions=torch.tensor([12, 13, 15, 12], dtype=torch.long),
+        seq_lens=torch.tensor([13, 14, 16, 13], dtype=torch.long),
+        extend_seq_lens=torch.tensor([1, 1, 1, 1], dtype=torch.long),
+        cu_seqlens_q=torch.tensor([0, 1, 2, 3, 4], dtype=torch.long),
+        req_pool_indices=torch.tensor([10, 20, 30, 40], dtype=torch.long),
+    )
+
+
+class TestConstruction:
+    def test_basic_prefill_constructs(self):
+        fb = _make_basic_prefill()
+        assert fb.is_prefill
+        assert not fb.is_decode
+        assert fb.num_seqs == 4
+        assert fb.num_tokens == 52
+
+    def test_basic_decode_constructs(self):
+        fb = _make_basic_decode()
+        assert fb.is_decode
+        assert not fb.is_prefill
+        assert fb.num_seqs == 4
+        assert fb.num_tokens == 4
+
+    def test_idle_empty_constructs(self):
+        fb = DSV4ForwardBatch(
+            forward_mode=DSV4ForwardMode.IDLE,
+            positions=torch.zeros(0, dtype=torch.long),
+            seq_lens=torch.zeros(0, dtype=torch.long),
+            extend_seq_lens=torch.zeros(0, dtype=torch.long),
+            cu_seqlens_q=torch.zeros(1, dtype=torch.long),
+            req_pool_indices=torch.zeros(0, dtype=torch.long),
+        )
+        assert fb.num_seqs == 0
+        assert fb.num_tokens == 0
+
+
+class TestInvariants:
+    def test_positions_must_be_1d(self):
+        with pytest.raises(AssertionError, match="positions must be 1-D"):
+            DSV4ForwardBatch(
+                forward_mode=DSV4ForwardMode.PREFILL,
+                positions=torch.zeros(2, 3, dtype=torch.long),
+                seq_lens=torch.tensor([3], dtype=torch.long),
+                extend_seq_lens=torch.tensor([3], dtype=torch.long),
+                cu_seqlens_q=torch.tensor([0, 3], dtype=torch.long),
+                req_pool_indices=torch.tensor([0], dtype=torch.long),
+            )
+
+    def test_cu_seqlens_q_size_must_be_num_seqs_plus_1(self):
+        with pytest.raises(AssertionError, match="cu_seqlens_q.numel"):
+            DSV4ForwardBatch(
+                forward_mode=DSV4ForwardMode.PREFILL,
+                positions=torch.tensor([0, 1, 2], dtype=torch.long),
+                seq_lens=torch.tensor([3], dtype=torch.long),
+                extend_seq_lens=torch.tensor([3], dtype=torch.long),
+                cu_seqlens_q=torch.tensor([0, 3, 6], dtype=torch.long),  # wrong size
+                req_pool_indices=torch.tensor([0], dtype=torch.long),
+            )
+
+    def test_cu_seqlens_q_tail_must_match_num_tokens(self):
+        with pytest.raises(AssertionError, match="cu_seqlens_q\\[-1\\]"):
+            DSV4ForwardBatch(
+                forward_mode=DSV4ForwardMode.PREFILL,
+                positions=torch.tensor([0, 1, 2], dtype=torch.long),
+                seq_lens=torch.tensor([3], dtype=torch.long),
+                extend_seq_lens=torch.tensor([3], dtype=torch.long),
+                cu_seqlens_q=torch.tensor([0, 5], dtype=torch.long),  # tail != 3
+                req_pool_indices=torch.tensor([0], dtype=torch.long),
+            )
+
+    def test_decode_mode_requires_all_extend_eq_1(self):
+        with pytest.raises(AssertionError, match="DECODE mode requires"):
+            DSV4ForwardBatch(
+                forward_mode=DSV4ForwardMode.DECODE,
+                positions=torch.tensor([12, 13, 14], dtype=torch.long),
+                seq_lens=torch.tensor([13, 14], dtype=torch.long),
+                extend_seq_lens=torch.tensor([1, 2], dtype=torch.long),  # second seq has 2
+                cu_seqlens_q=torch.tensor([0, 1, 3], dtype=torch.long),
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.long),
+            )
+
+    def test_prefill_mode_requires_at_least_one_extend_gt_1(self):
+        with pytest.raises(AssertionError, match="PREFILL mode requires"):
+            DSV4ForwardBatch(
+                forward_mode=DSV4ForwardMode.PREFILL,
+                positions=torch.tensor([12, 13], dtype=torch.long),
+                seq_lens=torch.tensor([13, 14], dtype=torch.long),
+                extend_seq_lens=torch.tensor([1, 1], dtype=torch.long),
+                cu_seqlens_q=torch.tensor([0, 1, 2], dtype=torch.long),
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.long),
+            )
+
+    def test_dtype_must_be_int(self):
+        with pytest.raises(AssertionError, match="positions must be int dtype"):
+            DSV4ForwardBatch(
+                forward_mode=DSV4ForwardMode.DECODE,
+                positions=torch.tensor([12.0], dtype=torch.float32),
+                seq_lens=torch.tensor([13], dtype=torch.long),
+                extend_seq_lens=torch.tensor([1], dtype=torch.long),
+                cu_seqlens_q=torch.tensor([0, 1], dtype=torch.long),
+                req_pool_indices=torch.tensor([0], dtype=torch.long),
+            )
+
+
+class TestFromAttnMetadata:
+    def test_prefill_4seqs_packed(self):
+        """The exact W3.2 silicon test scenario."""
+        cu = torch.tensor([0, 12, 25, 40, 52], dtype=torch.long)
+        block_tables = torch.tensor(
+            [[10, 11], [20, 21], [30, 31], [40, 41]], dtype=torch.long
+        )
+        context_lens = torch.zeros(4, dtype=torch.long)  # fresh request
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=block_tables, context_lens=context_lens
+        )
+        positions = torch.tensor(
+            list(range(12)) + list(range(13)) + list(range(15)) + list(range(12)),
+            dtype=torch.long,
+        )
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        assert fb.is_prefill
+        assert fb.num_seqs == 4
+        assert fb.num_tokens == 52
+        assert fb.extend_seq_lens.tolist() == [12, 13, 15, 12]
+        assert fb.req_pool_indices.tolist() == [10, 20, 30, 40]
+
+    def test_decode_4seqs_lockstep(self):
+        cu = torch.tensor([0, 1, 2, 3, 4], dtype=torch.long)
+        block_tables = torch.tensor(
+            [[10, 11], [20, 21], [30, 31], [40, 41]], dtype=torch.long
+        )
+        context_lens = torch.tensor([12, 13, 15, 12], dtype=torch.long)
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=block_tables, context_lens=context_lens
+        )
+        positions = torch.tensor([12, 13, 15, 12], dtype=torch.long)
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        assert fb.is_decode
+        assert fb.seq_lens.tolist() == [13, 14, 16, 13]
+        assert fb.extend_seq_lens.tolist() == [1, 1, 1, 1]
+        assert fb.req_pool_indices.tolist() == [10, 20, 30, 40]
+
+    def test_no_block_tables_falls_back_to_arange(self):
+        cu = torch.tensor([0, 5], dtype=torch.long)
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=None, context_lens=None
+        )
+        positions = torch.arange(5, dtype=torch.long)
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        assert fb.req_pool_indices.tolist() == [0]
+
+    def test_empty_batch_yields_idle(self):
+        cu = torch.tensor([0], dtype=torch.long)
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=None, context_lens=None
+        )
+        positions = torch.zeros(0, dtype=torch.long)
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        assert fb.forward_mode == DSV4ForwardMode.IDLE
+
+    def test_int32_cu_normalized_to_long(self):
+        cu = torch.tensor([0, 3], dtype=torch.int32)
+        attn_meta = SimpleNamespace(cu_seqlens_q=cu, block_tables=None, context_lens=None)
+        positions = torch.tensor([0, 1, 2], dtype=torch.int32)
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        assert fb.positions.dtype == torch.long
+        assert fb.cu_seqlens_q.dtype == torch.long

--- a/tests/test_dsv4_forward_batch.py
+++ b/tests/test_dsv4_forward_batch.py
@@ -201,3 +201,88 @@ class TestFromAttnMetadata:
         fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
         assert fb.positions.dtype == torch.long
         assert fb.cu_seqlens_q.dtype == torch.long
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="needs CUDA for cross-device test"
+    )
+    def test_cpu_metadata_with_cuda_positions_normalizes_to_positions_device(self):
+        """P1.2 regression: previously cu stayed on CPU while positions
+        was on CUDA, causing __post_init__ device assert to fail. Adapter
+        must move ALL metadata tensors to positions.device.
+        """
+        cu = torch.tensor([0, 12, 25], dtype=torch.long, device="cpu")
+        block_tables = torch.tensor([[10, 11], [20, 21]], dtype=torch.long, device="cpu")
+        context_lens = torch.zeros(2, dtype=torch.long, device="cpu")
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=block_tables, context_lens=context_lens
+        )
+        positions = torch.tensor(
+            list(range(12)) + list(range(13)), dtype=torch.long, device="cuda"
+        )
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        # All metadata tensors covered by __post_init__ device-invariant
+        # must now share positions.device (= cuda).
+        assert fb.positions.device.type == "cuda"
+        assert fb.cu_seqlens_q.device.type == "cuda"
+        assert fb.extend_seq_lens.device.type == "cuda"
+        assert fb.seq_lens.device.type == "cuda"
+        assert fb.req_pool_indices.device.type == "cuda"
+
+    def test_cpu_only_metadata_all_devices_match_positions(self):
+        """CPU-only sanity: when positions and metadata both start on
+        CPU, __post_init__ device-uniformity is satisfied (regression-
+        guards the case where the adapter accidentally diverged devices).
+        """
+        cu = torch.tensor([0, 12, 25], dtype=torch.long)
+        block_tables = torch.tensor([[10, 11], [20, 21]], dtype=torch.long)
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=block_tables, context_lens=None
+        )
+        positions = torch.tensor(
+            list(range(12)) + list(range(13)), dtype=torch.long
+        )
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        ref_dev = positions.device
+        for fname in ("cu_seqlens_q", "extend_seq_lens", "seq_lens", "req_pool_indices"):
+            assert getattr(fb, fname).device == ref_dev, (
+                f"{fname} on {getattr(fb, fname).device}, expected {ref_dev}"
+            )
+
+
+class TestPoolSlotUniqueness:
+    """P2.1: req_pool_indices is a W4.1 placeholder filled with
+    block_tables[:, 0]; under prefix caching two seqs may share a first
+    block. `assert_pool_slot_unique()` is the explicit gate for callers
+    that need uniqueness."""
+
+    def test_unique_passes(self):
+        fb = _make_basic_decode()
+        # No exception
+        fb.assert_pool_slot_unique()
+
+    def test_duplicate_raises(self):
+        # Simulate a prefix-cache collision: two seqs share first block.
+        cu = torch.tensor([0, 1, 2], dtype=torch.long)
+        block_tables = torch.tensor(
+            [[10, 11], [10, 12]], dtype=torch.long  # same first block
+        )
+        context_lens = torch.tensor([5, 5], dtype=torch.long)
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=block_tables, context_lens=context_lens
+        )
+        positions = torch.tensor([5, 5], dtype=torch.long)
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        # The placeholder copies the colliding first-block ids verbatim.
+        assert fb.req_pool_indices.tolist() == [10, 10]
+        with pytest.raises(ValueError, match="not unique"):
+            fb.assert_pool_slot_unique()
+
+    def test_empty_batch_skips_check(self):
+        cu = torch.tensor([0], dtype=torch.long)
+        attn_meta = SimpleNamespace(
+            cu_seqlens_q=cu, block_tables=None, context_lens=None
+        )
+        positions = torch.zeros(0, dtype=torch.long)
+        fb = DSV4ForwardBatch.from_attn_metadata(attn_meta, positions)
+        # No exception even though there are no seqs
+        fb.assert_pool_slot_unique()


### PR DESCRIPTION
## Summary

First step of the SGLang/vLLM-isomorphic DSV4 refactor (Path 3 of #37). **Structure only — no model behavior changes.**

Defines `DSV4ForwardBatch` and the adapter from ATOM's existing `AttentionMetaData`, so subsequent W4 sub-PRs can land independently:

- W4.2: engine-owned KV/state pools (replaces the W4.1 placeholder `req_pool_indices`)
- W4.3: `DeepseekV4Attention.forward(x, positions, forward_batch)` consumption
- W4.4: Compressor / Indexer state moved out of `nn.Module` register_buffer
- W4.5: conc=4 variable-length silicon correctness — runtime evidence
- W4.6: perf optimization (in-graph metadata, fused kernels)

## Files

- `atom/utils/dsv4_forward_batch.py` (new): `DSV4ForwardMode` enum + `DSV4ForwardBatch` dataclass with shape/dtype/device invariants + `from_attn_metadata()` adapter + `assert_pool_slot_unique()` runtime gate
- `tests/test_dsv4_forward_batch.py` (new): 19 UT covering construction, invariant violations, adapter paths (CUDA-skipped cross-device + CPU-only sanity), pool-slot uniqueness gate

## Reference design

- SGLang `python/sglang/srt/models/deepseek_v4.py:819` — `MQALayer.forward(x, positions, forward_batch)`
- vLLM `vllm/model_executor/layers/deepseek_v4_attention.py:650`

## Review fixes (commit `ba3aea3` on top of initial scaffold)

- **P1.2 device-movement bug**: `from_attn_metadata` now coerces ALL metadata tensors to `positions.device` before deriving `extend_seq_lens` etc. Previously CPU `cu_seqlens_q` + GPU `positions` would fail `__post_init__`'s device-uniformity invariant.
- **P2.1 `req_pool_indices` placeholder**: docstring marks it explicitly as W4.1 PLACEHOLDER (set to `block_tables[:, 0]` which is NOT stable-unique under prefix caching). Added `assert_pool_slot_unique()` for callers needing the guarantee. W4.2 replaces the adapter with the engine-pool's true slot allocator.

## Test plan

Verified locally on `atom_dsv4_feat` container, `/opt/venv/bin/python -m pytest`:

- [x] `tests/test_dsv4_forward_batch.py` → **19 passed** (was 14 in the initial commit; +5 added in commit `ba3aea3` covering CUDA cross-device adapter, CPU-only device sanity, pool-slot collision detection)
- [x] Regression: this PR adds new files only, does not modify model code → 0 regression risk on existing tests

### Follow-ups (NOT covered by this PR; explicit)

These belong to subsequent W4 sub-PRs, not this scaffold:

- [ ] Engine-owned KV/state pool with stable per-request slot IDs (W4.2)
- [ ] `DeepseekV4Attention.forward(x, positions, forward_batch)` consumption — model behavior change (W4.3)
- [ ] Compressor / Indexer state migration to engine pools (W4.4)
- [ ] Multi-request correctness silicon validation: 4-prompt smoke + gsm8k limit=20 conc=4 (W4.5)
- [ ] Perf optimization on top of the corrected baseline (W4.6)

## Sequencing

Per #37: this PR's base (`feat/dsv4-multireq-kvcache-reform`) targets PR #36 directly. **Do not merge before PR #36 + #38 finalize** — GitHub would otherwise land the changes on the PR #36 branch. Sequence:

1. Merge PR #36 (W3 stable foundation)
2. Retarget + merge PR #38 (Path 2 guard)
3. Retarget this PR (#39) to `main`
4. Merge W4.1 forward_batch scaffold
5. Start W4.2 (engine-owned pool with explicit request IDs replacing the placeholder)

## References

- #37 — decision and W4 PR-split plan
- #36 — frozen W3 stable foundation; this PR bases on its head
- #38 — Path 2 hard-assert sibling

🤖 Generated with [Claude Code](https://claude.com/claude-code)