### PR TITLE
[W4.2] DSV4 engine-owned KV/state pool (issue #37 Path 3)

### DIFF
--- a/atom/engine/__init__.py
+++ b/atom/engine/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""ATOM engine-side runtime helpers (W4.x — issue #37)."""

--- a/atom/engine/kv_pool/__init__.py
+++ b/atom/engine/kv_pool/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Engine-owned per-request KV / state pools (W4.2 — issue #37)."""
+
+from atom.engine.kv_pool.dsv4_pool import DSV4KVPool, DSV4KVPoolConfig
+
+__all__ = ["DSV4KVPool", "DSV4KVPoolConfig"]

--- a/atom/engine/kv_pool/dsv4_pool.py
+++ b/atom/engine/kv_pool/dsv4_pool.py
@@ -1,0 +1,464 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Engine-owned DSV4 KV / state pool (W4.2 — issue #37).
+
+REPLACES the W4.1 placeholder in ``atom/utils/dsv4_forward_batch.py``::
+
+    req_pool_indices = block_tables[:, 0]   # NOT stable-unique under prefix caching
+
+with a stable per-request slot allocator (``admit_request`` / ``finish_request``)
+plus a ring-encoding helper for ``out_cache_loc``.
+
+Patterns mirrored:
+- Free-list allocator: ``atom/model_engine/block_manager.py:215`` (free_mamba_slots).
+- Ring-loc formula: SGLang
+  ``python/sglang/srt/mem_cache/compress_state.py:147-153`` (CompressStatePool).
+- Three-pool grouping: SGLang
+  ``python/sglang/srt/mem_cache/deepseekv4_memory_pool.py:356`` (DeepSeekV4TokenToKVPool).
+- Per-request token pool API: SGLang ReqToTokenPool.
+
+W4.2 SCOPE
+----------
+- This file (NEW), the ``DSV4ForwardBatch.from_engine_state`` ctor, unit tests.
+- NO model changes (``atom/models/deepseek_v4.py`` untouched). That's W4.3+.
+- Scheduler ``admit/finish`` wiring is deferred to W4.2b / W4.3.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional
+
+import torch
+
+# ---------------------------------------------------------------------------
+# Typing helpers
+# ---------------------------------------------------------------------------
+
+RingName = Literal["main", "compressor", "indexer"]
+
+
+@dataclass
+class DSV4KVPoolConfig:
+    """Static config for the pool. Built from atom.config.Config in W4.2 wire-up.
+
+    Fields
+    ------
+    max_active_seqs: ``Config.max_num_seqs`` (today default 512). Hard cap on
+        concurrently-admitted DSV4 requests.
+    num_layers: total transformer layers (target + draft if MTP).
+    num_c4_layers / num_c128_layers: subset of ``num_layers`` whose
+        ``compress_ratio`` is 4 / 128 respectively. Drives Compressor/Indexer
+        pool sizing. From ``DeepseekV4Args.compress_ratios``.
+    head_dim, rope_head_dim: from ``DeepseekV4Args``.
+    window_size: main attention sliding window (``args.window_size``).
+    max_seq_len: ``args.max_seq_len`` for indexer cache sizing.
+    ring_size_main / ring_size_compressor / ring_size_indexer: ring lengths
+        for the three caches. Mirrors SGLang
+        ``get_compress_state_ring_size(compress_ratio, is_speculative)``
+        (``compress_state.py``-adjacent code; values 4→8, 128→128 today).
+    compress_ratio_per_layer: one entry per layer (0 / 4 / 128). Drives
+        ``view_for_layer`` dispatch — layers with ratio 0 only have a main
+        kv view; ratio 4 layers also have compressor + indexer; ratio 128
+        layers have compressor but no indexer.
+    state_inner_dim: inner feature dim of the compressor state tensors.
+        Sized as ``coff * head_dim`` upstream. Kept configurable so unit
+        tests can pick small values.
+    dtype: storage dtype (typically ``torch.bfloat16`` for kv).
+    state_dtype: dtype for compressor ``kv_state`` / ``score_state`` (fp32
+        per ``deepseek_v4.py:662-684``).
+    device: target device (``cuda`` in production, ``cpu`` in unit tests).
+    """
+
+    max_active_seqs: int
+    num_layers: int
+    num_c4_layers: int
+    num_c128_layers: int
+    head_dim: int
+    rope_head_dim: int
+    window_size: int
+    max_seq_len: int
+    ring_size_main: int
+    ring_size_compressor: int
+    ring_size_indexer: int
+    compress_ratio_per_layer: List[int] = field(default_factory=list)
+    state_inner_dim: int = 0
+    dtype: torch.dtype = torch.bfloat16
+    state_dtype: torch.dtype = torch.float32
+    device: torch.device = field(default_factory=lambda: torch.device("cpu"))
+
+    def __post_init__(self) -> None:
+        # Default state_inner_dim to head_dim if caller didn't provide one.
+        if self.state_inner_dim == 0:
+            self.state_inner_dim = self.head_dim
+        if len(self.compress_ratio_per_layer) != self.num_layers:
+            raise ValueError(
+                f"compress_ratio_per_layer length {len(self.compress_ratio_per_layer)} "
+                f"!= num_layers {self.num_layers}"
+            )
+        # Sanity: declared c4/c128 counts must match the per-layer list.
+        actual_c4 = sum(1 for r in self.compress_ratio_per_layer if r == 4)
+        actual_c128 = sum(1 for r in self.compress_ratio_per_layer if r == 128)
+        if actual_c4 != self.num_c4_layers:
+            raise ValueError(
+                f"num_c4_layers={self.num_c4_layers} but compress_ratio_per_layer "
+                f"contains {actual_c4} layers with ratio==4"
+            )
+        if actual_c128 != self.num_c128_layers:
+            raise ValueError(
+                f"num_c128_layers={self.num_c128_layers} but compress_ratio_per_layer "
+                f"contains {actual_c128} layers with ratio==128"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Pool
+# ---------------------------------------------------------------------------
+
+
+class DSV4KVPool:
+    """Engine-owned per-request KV/state pool for DSV4.
+
+    Responsibilities
+    ----------------
+    1. Stable slot allocator: ``admit_request(seq_id) → slot_idx`` invariant
+       across the seq's lifetime, freed on ``finish_request(seq_id)``. Slots
+       are dense in ``[0, max_active_seqs)``.
+    2. Owns the on-device tensors for the three logical caches: main
+       sliding-window KV, Compressor overlap state, Indexer compressed-KV.
+       (W4.2 declares them; W4.4 has the model start consuming them.)
+    3. Provides ``compute_out_cache_loc`` so the per-step ForwardBatch can
+       compute write positions without the model touching pool internals.
+
+    Invariants
+    ----------
+    - ``admit_request`` is idempotent; re-admit returns the same slot until
+      ``finish_request`` is called.
+    - ``finish_request`` is idempotent; finishing an unknown seq is a no-op
+      (matches Scheduler's defensive double-deallocate pattern at
+      ``scheduler.py:578`` and ``:730``).
+    - Two seqs with colliding ``block_tables[:, 0]`` get DIFFERENT slots.
+      This is the bug W4.2 fixes; covered by
+      ``test_prefix_cache_first_block_collision``.
+
+    Cudagraph / TP notes
+    --------------------
+    - ``get_slots`` returns a fresh device tensor per call; the model
+      consumes it via ``DSV4ForwardBatch.req_pool_indices`` which the graph
+      treats as an input tensor (not a pool query).
+    - Slot allocation runs Python-side BEFORE graph capture. All tensor ops
+      after that point (``compute_out_cache_loc``, ``view_for_layer``) are
+      graph-safe (``torch.bucketize`` + gather + modulo).
+    - TP/PP: pool is one per TP rank; same Scheduler ⇒ same slot map ⇒ no
+      cross-rank sync needed. (Cross-process Scheduler split is out of
+      scope; if introduced, slot map needs broadcasting — open Q3.)
+    """
+
+    # ---- construction ----
+
+    def __init__(self, config: DSV4KVPoolConfig) -> None:
+        self.cfg = config
+        self.max_active_seqs = config.max_active_seqs
+
+        # Slot allocator: LIFO stack so the warmest slot is reused first
+        # (cudagraph-friendly memory locality). Mirrors
+        # ``BlockManager.free_mamba_slots`` pattern in
+        # ``atom/model_engine/block_manager.py:215``.
+        # Storing as a list with pop()/append() gives LIFO semantics.
+        # Initial order [0, 1, ..., N-1] means first admit returns 0,
+        # second admit returns 1, etc. (slot N-1 sits at the bottom of
+        # the stack and is the last-recycled).
+        self._free: List[int] = list(range(self.max_active_seqs - 1, -1, -1))
+        self._seq_to_slot: Dict[int, int] = {}
+
+        # Per-cache tensors. Layouts mirror the model's existing
+        # ``register_buffer`` shapes (``deepseek_v4.py:662, :949, :1215``)
+        # so W4.4 can rebind without resizing.
+        self._main_kv: torch.Tensor
+        self._compressor_state: Optional[torch.Tensor]
+        self._compressor_score: Optional[torch.Tensor]
+        self._indexer_kv: Optional[torch.Tensor]
+
+        # Map global layer_id → per-pool layer index for compressor / indexer.
+        # Mirrors SGLang's _init_compressed_layer_mapping (deepseekv4_memory_pool.py).
+        self._compressor_layer_idx: Dict[int, int] = {}
+        self._indexer_layer_idx: Dict[int, int] = {}
+
+        self._build_buffers()
+
+    def _build_buffers(self) -> None:
+        """Allocate the three logical caches once, sized by ``cfg``.
+
+        Returns nothing; populates ``self._main_kv`` etc. Respects
+        ``cfg.device`` (cpu in unit tests) and ``cfg.dtype`` /
+        ``cfg.state_dtype``.
+
+        Layouts (must match model side at W4.4 rebinding):
+          - main_kv:           ``[num_layers, N, ring_main, head_dim]``     dtype
+          - compressor_state:  ``[num_compress_layers, N, ring_comp, state_inner_dim]``
+                               state_dtype (zero-init)
+          - compressor_score:  same shape as compressor_state, fp32, fill -inf
+          - indexer_kv:        ``[num_c4_layers, N, ring_idx, head_dim]``   dtype
+                               (None if num_c4_layers == 0)
+        """
+        cfg = self.cfg
+        N = cfg.max_active_seqs
+
+        self._main_kv = torch.zeros(
+            (cfg.num_layers, N, cfg.ring_size_main, cfg.head_dim),
+            dtype=cfg.dtype,
+            device=cfg.device,
+        )
+
+        # Compressor pool: one slab per layer with ratio in {4, 128}.
+        num_compress_layers = cfg.num_c4_layers + cfg.num_c128_layers
+        if num_compress_layers > 0:
+            self._compressor_state = torch.zeros(
+                (
+                    num_compress_layers,
+                    N,
+                    cfg.ring_size_compressor,
+                    cfg.state_inner_dim,
+                ),
+                dtype=cfg.state_dtype,
+                device=cfg.device,
+            )
+            self._compressor_score = torch.full(
+                (
+                    num_compress_layers,
+                    N,
+                    cfg.ring_size_compressor,
+                    cfg.state_inner_dim,
+                ),
+                float("-inf"),
+                dtype=cfg.state_dtype,
+                device=cfg.device,
+            )
+            # Build global-layer → compressor-pool index map (in cfg order).
+            comp_idx = 0
+            for layer_id, ratio in enumerate(cfg.compress_ratio_per_layer):
+                if ratio in (4, 128):
+                    self._compressor_layer_idx[layer_id] = comp_idx
+                    comp_idx += 1
+        else:
+            self._compressor_state = None
+            self._compressor_score = None
+
+        # Indexer pool: one slab per c4 layer.
+        if cfg.num_c4_layers > 0:
+            self._indexer_kv = torch.zeros(
+                (cfg.num_c4_layers, N, cfg.ring_size_indexer, cfg.head_dim),
+                dtype=cfg.dtype,
+                device=cfg.device,
+            )
+            idx_idx = 0
+            for layer_id, ratio in enumerate(cfg.compress_ratio_per_layer):
+                if ratio == 4:
+                    self._indexer_layer_idx[layer_id] = idx_idx
+                    idx_idx += 1
+        else:
+            self._indexer_kv = None
+
+    # ---- lifecycle (called by Scheduler) ----
+
+    def admit_request(self, seq_id: int) -> int:
+        """Assign a stable slot to ``seq_id``. Idempotent.
+
+        Raises ``RuntimeError`` if no free slot (caller is the scheduler,
+        which already gates on ``max_num_seqs`` — this is a defensive
+        guard).
+
+        Returns the slot index in ``[0, max_active_seqs)``.
+        """
+        slot = self._seq_to_slot.get(seq_id)
+        if slot is not None:
+            return slot
+        if not self._free:
+            raise RuntimeError(
+                f"DSV4KVPool: no free slot (max_active_seqs={self.max_active_seqs}). "
+                "Scheduler should have gated this admit on max_num_seqs."
+            )
+        slot = self._free.pop()
+        self._seq_to_slot[seq_id] = slot
+        return slot
+
+    def finish_request(self, seq_id: int) -> None:
+        """Free the slot held by ``seq_id``. Idempotent (no-op if unknown).
+
+        Note on Compressor/Indexer state lifetime: the slot's pool rows are
+        NOT proactively zeroed here (cudagraph compat — would require a
+        sync). Next admit overwrites them on first prefill. If a future
+        debug build wants zero-on-free, gate it behind an env var.
+
+        Preemption semantics (per design § open Q4): when Scheduler
+        preempts a seq, it MUST call ``finish_request`` so the slot is
+        reusable. The seq will be re-admitted on resume and get a fresh
+        slot — Compressor/Indexer state is therefore stale, but that's
+        fine because preemption already invalidates KV (the seq
+        re-prefills from scratch).
+        """
+        slot = self._seq_to_slot.pop(seq_id, None)
+        if slot is None:
+            return
+        self._free.append(slot)
+
+    def get_slot(self, seq_id: int) -> int:
+        """Return the slot for an admitted seq.
+
+        Raises ``KeyError`` if ``seq_id`` is not currently admitted.
+        """
+        return self._seq_to_slot[seq_id]
+
+    def get_slots(self, seq_ids: List[int]) -> torch.Tensor:
+        """Vectorized lookup. Returns a fresh ``[len(seq_ids)]`` long
+        tensor on ``cfg.device`` mapping each input seq to its slot.
+
+        DO NOT cache the returned tensor across steps; cache only the int
+        map (``self._seq_to_slot``). The tensor is per-step input to the
+        cudagraph.
+        """
+        slots = [self._seq_to_slot[s] for s in seq_ids]
+        return torch.tensor(slots, dtype=torch.long, device=self.cfg.device)
+
+    def num_free_slots(self) -> int:
+        return len(self._free)
+
+    def num_active_seqs(self) -> int:
+        return len(self._seq_to_slot)
+
+    # ---- per-step indexing (called by ForwardBatch builder) ----
+
+    def compute_out_cache_loc(
+        self,
+        positions: torch.Tensor,
+        slot_indices: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        ring: RingName = "main",
+    ) -> torch.Tensor:
+        """Per-token absolute write slot in the chosen cache's flat ring.
+
+        Formula (mirrors SGLang
+        ``CompressStatePool.translate_from_swa_loc_to_state_loc``,
+        ``compress_state.py:147``)::
+
+            seg_id = bucketize(token_idx, cu_seqlens_q[1:])  # which seq each token belongs to
+            slot   = slot_indices[seg_id]                    # [num_tokens]
+            return slot * ring_size + (positions % ring_size)  # [num_tokens]
+
+        Args
+        ----
+        positions: ``[num_tokens]`` long, per-token absolute position
+            (``DSV4ForwardBatch.positions``).
+        slot_indices: ``[num_seqs]`` long, per-seq slot id
+            (``DSV4ForwardBatch.req_pool_indices``).
+        cu_seqlens_q: ``[num_seqs+1]`` long, cumulative-tokens-per-seq
+            prefix (``DSV4ForwardBatch.cu_seqlens_q``).
+        ring: which cache's ring size to use.
+
+        Returns
+        -------
+        ``[num_tokens]`` long tensor, on ``positions.device``.
+
+        Prefill semantics
+        -----------------
+        For a fresh seq (slot=k, S new tokens at positions=[0..S-1]):
+        ``out = [k*R, k*R+1, ..., k*R+S-1]``.
+
+        Decode semantics
+        ----------------
+        Each seq emits 1 token at position p:
+        ``out[i] = slot_indices[i] * R + (p % R)``.
+
+        Mixed batch
+        -----------
+        ``cu_seqlens_q`` correctly demarcates each seq's token span, so
+        the same kernel works for prefill+decode mixed batches.
+        """
+        ring_size = self._ring_size(ring)
+        device = positions.device
+        T = positions.numel()
+        if T == 0:
+            return torch.zeros(0, dtype=torch.long, device=device)
+
+        # Token index in the packed batch.
+        token_idx = torch.arange(T, dtype=torch.long, device=device)
+
+        # ``bucketize(x, boundaries, right=True)`` returns the index of the
+        # smallest boundary STRICTLY GREATER than x (``searchsorted`` side
+        # 'right'). With boundaries = cu_seqlens_q[1:] (right edges of each
+        # seq's span), token i lands in the seq whose right edge first
+        # exceeds i. ``right=False`` would treat ``token == boundary`` as
+        # belonging to the *previous* segment, off-by-one for boundary
+        # tokens — the exact bug caught by the decode-lockstep UT.
+        cu_right = cu_seqlens_q[1:].to(device=device, dtype=torch.long)
+        seg_id = torch.bucketize(token_idx, cu_right, right=True)
+
+        # Gather slot per token; align dtype/device with positions.
+        slots = slot_indices.to(device=device, dtype=torch.long)
+        slot_per_token = slots[seg_id]
+
+        positions_long = positions.to(torch.long)
+        return slot_per_token * ring_size + (positions_long % ring_size)
+
+    def _ring_size(self, ring: RingName) -> int:
+        if ring == "main":
+            return self.cfg.ring_size_main
+        if ring == "compressor":
+            return self.cfg.ring_size_compressor
+        if ring == "indexer":
+            return self.cfg.ring_size_indexer
+        raise ValueError(f"unknown ring {ring!r}")
+
+    # ---- model wiring (consumed in W4.3 / W4.4) ----
+
+    def view_for_layer(self, layer_id: int) -> Dict[str, Optional[torch.Tensor]]:
+        """Per-layer zero-copy views into the pool's tensors.
+
+        Returned dict (NOT NamedTuple — extensibility in W4.5+)::
+
+            {
+              "kv_cache":    main_kv slice for this layer,
+              "kv_state":    compressor kv_state slice (None for compress_ratio=0),
+              "score_state": compressor score_state slice (None if no compressor),
+              "indexer_kv":  indexer cache slice (None unless compress_ratio=4),
+            }
+
+        W4.3 will replace ``self.kv_cache[rows, ...]`` in
+        ``deepseek_v4.py:Attention.forward`` (line 1215 register_buffer)
+        with ``pool.view_for_layer(layer_id)["kv_cache"]``. W4.4 drops
+        the ``register_buffer`` declarations entirely.
+
+        Slicing is index-only (``[layer_id]``), guaranteed contiguous in
+        the layout chosen in ``_build_buffers``. Consumers may further
+        gather by ``slot_indices`` for per-seq rows.
+        """
+        if not 0 <= layer_id < self.cfg.num_layers:
+            raise IndexError(
+                f"layer_id={layer_id} out of range [0, {self.cfg.num_layers})"
+            )
+
+        ratio = self.cfg.compress_ratio_per_layer[layer_id]
+
+        kv_view = self._main_kv[layer_id]
+
+        kv_state_view: Optional[torch.Tensor] = None
+        score_state_view: Optional[torch.Tensor] = None
+        indexer_view: Optional[torch.Tensor] = None
+
+        if ratio in (4, 128) and self._compressor_state is not None:
+            comp_idx = self._compressor_layer_idx[layer_id]
+            kv_state_view = self._compressor_state[comp_idx]
+            assert self._compressor_score is not None
+            score_state_view = self._compressor_score[comp_idx]
+
+        if ratio == 4 and self._indexer_kv is not None:
+            idx_idx = self._indexer_layer_idx[layer_id]
+            indexer_view = self._indexer_kv[idx_idx]
+
+        return {
+            "kv_cache": kv_view,
+            "kv_state": kv_state_view,
+            "score_state": score_state_view,
+            "indexer_kv": indexer_view,
+        }

--- a/atom/utils/dsv4_forward_batch.py
+++ b/atom/utils/dsv4_forward_batch.py
@@ -30,9 +30,14 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, List, Optional
 
 import torch
+
+if TYPE_CHECKING:
+    # Avoid a hard import: keeps this module test-friendly and breaks no
+    # legacy callers that haven't yet pulled in the engine package.
+    from atom.engine.kv_pool import DSV4KVPool
 
 
 class DSV4ForwardMode(enum.Enum):
@@ -220,22 +225,35 @@ class DSV4ForwardBatch:
         cls,
         attn_metadata: Any,
         positions: torch.Tensor,
+        seq_ids: Optional[List[int]] = None,
+        pool: Optional["DSV4KVPool"] = None,
     ) -> "DSV4ForwardBatch":
         """Adapter: construct DSV4ForwardBatch from ATOM's
         `forward_context.attn_metadata` + positions tensor.
 
-        Used during W4.1-W4.3 transition where the runtime still produces
-        ATOM's standard AttentionMetaData but the DSV4 model is being
-        migrated to consume DSV4ForwardBatch. Once W4.2 wires the engine-
-        owned pool and out_cache_loc, this adapter is upgraded to
-        `from_engine_state()` (W4.4).
+        Used during the W4.1-W4.3 transition where the runtime still
+        produces ATOM's standard AttentionMetaData but the DSV4 model is
+        being migrated to consume DSV4ForwardBatch. Once W4.4 lands the
+        recommended path is `from_engine_state()`.
+
+        Two operating modes
+        -------------------
+        - **W4.1 placeholder path** (``pool is None`` *or* ``seq_ids is
+          None``): ``req_pool_indices`` is filled with
+          ``block_tables[:, 0]``, the documented W4.1 placeholder. Not
+          stable-unique under prefix caching; callers needing uniqueness
+          must invoke ``assert_pool_slot_unique()``.
+        - **W4.2 pool path** (``pool`` and ``seq_ids`` both provided):
+          ``req_pool_indices = pool.get_slots(seq_ids)`` (stable-unique
+          per active seq) and ``out_cache_loc`` is populated via
+          ``pool.compute_out_cache_loc(...)`` for the main attention ring.
 
         ATOM normally builds attn_metadata tensors on CUDA, but a few
         paths (warmup, CPU-fallback unit tests) construct them on CPU
-        while `positions` lands on the model's GPU device. Normalize
-        ALL fields to `positions.device` here so __post_init__'s
-        device-uniformity invariant holds regardless of where the
-        upstream tensors started.
+        while `positions` lands on the model's GPU device. Normalize ALL
+        fields to ``positions.device`` here so __post_init__'s device-
+        uniformity invariant holds regardless of where the upstream
+        tensors started.
         """
         device = positions.device
         cu = attn_metadata.cu_seqlens_q.to(torch.long).to(device)
@@ -251,18 +269,35 @@ class DSV4ForwardBatch:
         else:
             seq_lens = extend_seq_lens.clone()
 
-        # req_pool_indices: see field docstring — W4.1 placeholder fills
-        # with block_tables[:, 0]; NOT stable-unique under prefix caching.
-        # Call assert_pool_slot_unique() if uniqueness is required.
         block_tables = getattr(attn_metadata, "block_tables", None)
-        if (
-            block_tables is not None
-            and block_tables.dim() == 2
-            and block_tables.shape[0] == num_seqs
-        ):
-            req_pool_indices = block_tables[:, 0].to(torch.long).to(device)
+        positions_long = positions.to(torch.long)
+
+        # ---- W4.2: prefer the engine pool when caller supplies it ----
+        # Pool path overrides the W4.1 ``block_tables[:, 0]`` placeholder
+        # with stable-unique slots and populates ``out_cache_loc``.
+        if pool is not None and seq_ids is not None and len(seq_ids) == num_seqs:
+            req_pool_indices = pool.get_slots(seq_ids).to(
+                device=device, dtype=torch.long
+            )
+            out_cache_loc: Optional[torch.Tensor] = pool.compute_out_cache_loc(
+                positions=positions_long,
+                slot_indices=req_pool_indices,
+                cu_seqlens_q=cu,
+                ring="main",
+            )
         else:
-            req_pool_indices = torch.arange(num_seqs, dtype=torch.long, device=device)
+            # ---- W4.1 placeholder path (legacy callers without pool) ----
+            if (
+                block_tables is not None
+                and block_tables.dim() == 2
+                and block_tables.shape[0] == num_seqs
+            ):
+                req_pool_indices = block_tables[:, 0].to(torch.long).to(device)
+            else:
+                req_pool_indices = torch.arange(
+                    num_seqs, dtype=torch.long, device=device
+                )
+            out_cache_loc = None  # callers MUST call assert_pool_slot_unique()
 
         # forward_mode: if any seq has extend > 1, it's prefill (mixed batch
         # is also classified as PREFILL — the runtime will decide internal
@@ -280,10 +315,63 @@ class DSV4ForwardBatch:
         # __post_init__ asserts on are guaranteed to share device.
         return cls(
             forward_mode=mode,
-            positions=positions.to(torch.long),
+            positions=positions_long,
             seq_lens=seq_lens,
             extend_seq_lens=extend_seq_lens,
             cu_seqlens_q=cu,
             req_pool_indices=req_pool_indices,
+            out_cache_loc=out_cache_loc,
             block_tables=block_tables,
+            kv_pool=pool,
+        )
+
+    @classmethod
+    def from_engine_state(
+        cls,
+        forward_batch_state: Any,
+        pool: "DSV4KVPool",
+    ) -> "DSV4ForwardBatch":
+        """Construct a DSV4ForwardBatch directly from the engine's
+        ``forward_batch_state`` and the engine-owned pool.
+
+        Used after W4.4 lands, when the runtime stops producing
+        AttentionMetaData for DSV4. Until then, ``from_attn_metadata``
+        with the optional ``pool`` kwarg is the recommended path.
+
+        ``forward_batch_state`` contract (proposed; finalize in W4.3)
+        -------------------------------------------------------------
+        - ``.seq_ids``: ``list[int]`` (one per seq in the batch).
+        - ``.positions``: ``Tensor[num_tokens]``.
+        - ``.cu_seqlens_q``: ``Tensor[num_seqs+1]``.
+        - ``.extend_seq_lens``: ``Tensor[num_seqs]``.
+        - ``.seq_lens``: ``Tensor[num_seqs]``.
+        - ``.forward_mode``: ``DSV4ForwardMode``.
+        - ``.block_tables`` (optional): pass-through, may be ``None``.
+        """
+        positions = forward_batch_state.positions.to(torch.long)
+        device = positions.device
+        cu = forward_batch_state.cu_seqlens_q.to(torch.long).to(device)
+
+        slot_indices = pool.get_slots(forward_batch_state.seq_ids).to(
+            device=device, dtype=torch.long
+        )
+        out_cache_loc = pool.compute_out_cache_loc(
+            positions=positions,
+            slot_indices=slot_indices,
+            cu_seqlens_q=cu,
+            ring="main",
+        )
+
+        return cls(
+            forward_mode=forward_batch_state.forward_mode,
+            positions=positions,
+            seq_lens=forward_batch_state.seq_lens.to(torch.long).to(device),
+            extend_seq_lens=forward_batch_state.extend_seq_lens.to(torch.long).to(
+                device
+            ),
+            cu_seqlens_q=cu,
+            req_pool_indices=slot_indices,
+            out_cache_loc=out_cache_loc,
+            block_tables=getattr(forward_batch_state, "block_tables", None),
+            kv_pool=pool,
         )

--- a/tests/test_dsv4_pool.py
+++ b/tests/test_dsv4_pool.py
@@ -1,0 +1,425 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Unit tests for ``DSV4KVPool`` (W4.2 — issue #37).
+
+All tests run on CPU per ATOM CI constraint
+(``CLAUDE.md``: "all tests, no GPU needed"). One optional GPU smoke test
+is gated on ``torch.cuda.is_available``.
+
+W4.2 SCOPE: pool only. Scheduler integration tests live in
+``tests/test_scheduler.py`` once the admit/finish hooks land (W4.2b/W4.3).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from atom.engine.kv_pool import DSV4KVPool, DSV4KVPoolConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_cfg(
+    max_active_seqs: int = 4,
+    num_layers: int = 8,
+    head_dim: int = 16,
+    ring_main: int = 64,
+    ring_comp: int = 8,
+    ring_idx: int = 64,
+    state_inner_dim: int = 16,
+    device: str = "cpu",
+) -> DSV4KVPoolConfig:
+    """Default fixture: 8 layers, [0, 4, 4, 4, 4, 128, 128, 0] ratios.
+
+    => 4 c4 layers (1, 2, 3, 4), 2 c128 layers (5, 6), 2 plain layers (0, 7).
+    """
+    ratios = [0, 4, 4, 4, 4, 128, 128, 0][:num_layers]
+    num_c4 = sum(1 for r in ratios if r == 4)
+    num_c128 = sum(1 for r in ratios if r == 128)
+    return DSV4KVPoolConfig(
+        max_active_seqs=max_active_seqs,
+        num_layers=num_layers,
+        num_c4_layers=num_c4,
+        num_c128_layers=num_c128,
+        head_dim=head_dim,
+        rope_head_dim=head_dim // 2,
+        window_size=ring_main,
+        max_seq_len=4096,
+        ring_size_main=ring_main,
+        ring_size_compressor=ring_comp,
+        ring_size_indexer=ring_idx,
+        compress_ratio_per_layer=ratios,
+        state_inner_dim=state_inner_dim,
+        device=torch.device(device),
+        dtype=torch.bfloat16,
+        state_dtype=torch.float32,
+    )
+
+
+@pytest.fixture
+def pool() -> DSV4KVPool:
+    return DSV4KVPool(_make_cfg(max_active_seqs=4))
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_admit_returns_slot_in_range(pool: DSV4KVPool) -> None:
+    """Slot is in [0, max_active_seqs)."""
+    s = pool.admit_request(seq_id=42)
+    assert 0 <= s < 4
+    assert pool.num_active_seqs() == 1
+    assert pool.num_free_slots() == 3
+
+
+def test_admit_idempotent(pool: DSV4KVPool) -> None:
+    """Re-admitting same seq_id returns same slot, does not consume new free slot."""
+    s1 = pool.admit_request(7)
+    free_after_first = pool.num_free_slots()
+    s2 = pool.admit_request(7)
+    assert s1 == s2
+    # No additional slot consumed by the idempotent re-admit
+    assert pool.num_free_slots() == free_after_first
+
+
+def test_finish_recycles_slot(pool: DSV4KVPool) -> None:
+    """Slot recycle: a finished seq's slot becomes available (LIFO)."""
+    s_a = pool.admit_request(1)
+    pool.admit_request(2)
+    pool.admit_request(3)
+    pool.admit_request(4)
+    assert pool.num_free_slots() == 0
+    pool.finish_request(1)
+    assert pool.num_free_slots() == 1
+    s_e = pool.admit_request(5)
+    # LIFO free list: the just-freed slot is the one returned next.
+    assert s_e == s_a, "slot was not recycled in LIFO order"
+
+
+def test_finish_unknown_seq_is_noop(pool: DSV4KVPool) -> None:
+    """Defensive: scheduler may double-deallocate; pool must tolerate."""
+    pool.finish_request(seq_id=999)  # never admitted
+    pool.admit_request(1)
+    pool.finish_request(1)
+    pool.finish_request(1)  # second finish, no error
+    # Pool returned to empty, all slots free.
+    assert pool.num_active_seqs() == 0
+    assert pool.num_free_slots() == 4
+
+
+def test_overadmit_raises(pool: DSV4KVPool) -> None:
+    """max_active_seqs=4 — admitting a 5th distinct seq raises RuntimeError."""
+    for i in range(4):
+        pool.admit_request(i)
+    with pytest.raises(RuntimeError, match="no free slot"):
+        pool.admit_request(99)
+
+
+def test_get_slot_unknown_raises(pool: DSV4KVPool) -> None:
+    with pytest.raises(KeyError):
+        pool.get_slot(seq_id=12345)
+
+
+# ---------------------------------------------------------------------------
+# THE W4.1 BUG FIX: prefix-cache first-block collision
+# ---------------------------------------------------------------------------
+
+
+def test_prefix_cache_first_block_collision(pool: DSV4KVPool) -> None:
+    """Two seqs sharing ``block_tables[:, 0]`` (prefix cache hit) MUST get
+    DIFFERENT pool slots.
+
+    This is the exact failure mode of the W4.1 placeholder
+    (``req_pool_indices = block_tables[:, 0]``). The pool is the fix.
+    """
+    # Simulate prefix caching: both seqs would have the same first
+    # physical block id (e.g., 7) because they share a prefix. The pool
+    # never consults block_tables — it allocates by seq_id only.
+    seq_a, seq_b = 100, 101
+    s_a = pool.admit_request(seq_a)
+    s_b = pool.admit_request(seq_b)
+    assert s_a != s_b, (
+        "Pool slot must be stable-unique per request — even when "
+        "block_tables[:, 0] would collide under prefix caching. This "
+        "is the W4.1 → W4.2 contract."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Vectorized lookup
+# ---------------------------------------------------------------------------
+
+
+def test_get_slots_returns_device_tensor(pool: DSV4KVPool) -> None:
+    pool.admit_request(10)
+    pool.admit_request(20)
+    pool.admit_request(30)
+    t = pool.get_slots([10, 20, 30])
+    assert t.dtype == torch.long
+    assert t.device == pool.cfg.device
+    assert t.shape == (3,)
+    # Values must equal the per-seq slot:
+    assert t[0].item() == pool.get_slot(10)
+    assert t[1].item() == pool.get_slot(20)
+    assert t[2].item() == pool.get_slot(30)
+
+
+def test_get_slots_order_preserves_input(pool: DSV4KVPool) -> None:
+    pool.admit_request(1)
+    pool.admit_request(2)
+    t1 = pool.get_slots([1, 2])
+    t2 = pool.get_slots([2, 1])
+    assert t1.tolist() == [pool.get_slot(1), pool.get_slot(2)]
+    assert t2.tolist() == [pool.get_slot(2), pool.get_slot(1)]
+
+
+# ---------------------------------------------------------------------------
+# compute_out_cache_loc
+# ---------------------------------------------------------------------------
+
+
+def test_compute_out_cache_loc_prefill_single_seq(pool: DSV4KVPool) -> None:
+    """One fresh seq, S=10 prompt tokens.
+
+    positions=[0..9], slot=k => out_cache_loc=[k*R..k*R+9].
+    """
+    s = pool.admit_request(1)
+    R = pool.cfg.ring_size_main
+    positions = torch.arange(10, dtype=torch.long, device=pool.cfg.device)
+    slot_indices = torch.tensor([s], dtype=torch.long, device=pool.cfg.device)
+    cu = torch.tensor([0, 10], dtype=torch.long, device=pool.cfg.device)
+
+    out = pool.compute_out_cache_loc(positions, slot_indices, cu, ring="main")
+    expected = torch.arange(s * R, s * R + 10, dtype=torch.long)
+    assert torch.equal(out.cpu(), expected)
+
+
+def test_compute_out_cache_loc_decode_lockstep(pool: DSV4KVPool) -> None:
+    """4 seqs, each emits 1 token at its own absolute position.
+
+    Each ``out_cache_loc[i] = slot[i] * R + (positions[i] % R)``.
+    """
+    R = pool.cfg.ring_size_main
+    seq_ids = [11, 12, 13, 14]
+    for sid in seq_ids:
+        pool.admit_request(sid)
+    slot_indices = pool.get_slots(seq_ids)
+
+    # Decode at varied positions (well past the ring wraparound point)
+    positions = torch.tensor(
+        [R + 5, 2 * R + 0, 3, R - 1],
+        dtype=torch.long,
+        device=pool.cfg.device,
+    )
+    cu = torch.tensor([0, 1, 2, 3, 4], dtype=torch.long, device=pool.cfg.device)
+
+    out = pool.compute_out_cache_loc(positions, slot_indices, cu, ring="main")
+
+    expected = slot_indices * R + (positions % R)
+    assert torch.equal(out.cpu(), expected.cpu())
+
+
+def test_compute_out_cache_loc_mixed_batch(pool: DSV4KVPool) -> None:
+    """Mixed batch: seq A is prefill (S_a tokens), seq B is decode (1 token)."""
+    s_a = pool.admit_request(101)
+    s_b = pool.admit_request(102)
+    R = pool.cfg.ring_size_main
+    S_a = 6
+
+    positions = torch.cat(
+        [
+            torch.arange(S_a, dtype=torch.long),  # A: 0..5
+            torch.tensor([42], dtype=torch.long),  # B: pos=42
+        ]
+    ).to(pool.cfg.device)
+    slot_indices = torch.tensor([s_a, s_b], dtype=torch.long, device=pool.cfg.device)
+    cu = torch.tensor([0, S_a, S_a + 1], dtype=torch.long, device=pool.cfg.device)
+
+    out = pool.compute_out_cache_loc(positions, slot_indices, cu, ring="main")
+
+    expected = torch.cat(
+        [
+            torch.arange(s_a * R, s_a * R + S_a, dtype=torch.long),
+            torch.tensor([s_b * R + (42 % R)], dtype=torch.long),
+        ]
+    )
+    assert torch.equal(out.cpu(), expected)
+
+
+def test_compute_out_cache_loc_compressor_ring(pool: DSV4KVPool) -> None:
+    """Same formula, ``ring='compressor'`` uses the smaller ring size."""
+    s = pool.admit_request(1)
+    R_c = pool.cfg.ring_size_compressor
+    positions = torch.tensor([0, 3, 7, 11], dtype=torch.long, device=pool.cfg.device)
+    slot_indices = torch.tensor([s], dtype=torch.long, device=pool.cfg.device)
+    cu = torch.tensor([0, 4], dtype=torch.long, device=pool.cfg.device)
+
+    out = pool.compute_out_cache_loc(positions, slot_indices, cu, ring="compressor")
+    expected = s * R_c + positions % R_c
+    assert torch.equal(out.cpu(), expected.cpu())
+
+
+def test_compute_out_cache_loc_indexer_ring(pool: DSV4KVPool) -> None:
+    """``ring='indexer'`` uses the indexer-specific ring size."""
+    s = pool.admit_request(1)
+    R_i = pool.cfg.ring_size_indexer
+    positions = torch.tensor(
+        [0, R_i, R_i + 5], dtype=torch.long, device=pool.cfg.device
+    )
+    slot_indices = torch.tensor([s], dtype=torch.long, device=pool.cfg.device)
+    cu = torch.tensor([0, 3], dtype=torch.long, device=pool.cfg.device)
+
+    out = pool.compute_out_cache_loc(positions, slot_indices, cu, ring="indexer")
+    expected = s * R_i + positions % R_i
+    assert torch.equal(out.cpu(), expected.cpu())
+
+
+def test_compute_out_cache_loc_unknown_ring(pool: DSV4KVPool) -> None:
+    pool.admit_request(1)
+    positions = torch.tensor([0], dtype=torch.long)
+    slot_indices = torch.tensor([0], dtype=torch.long)
+    cu = torch.tensor([0, 1], dtype=torch.long)
+    with pytest.raises(ValueError, match="unknown ring"):
+        pool.compute_out_cache_loc(positions, slot_indices, cu, ring="bogus")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# view_for_layer
+# ---------------------------------------------------------------------------
+
+
+def test_view_for_layer_main_shape(pool: DSV4KVPool) -> None:
+    """layer_id=0 (compress_ratio=0 in fixture) returns main kv only."""
+    view = pool.view_for_layer(layer_id=0)
+    assert view["kv_cache"] is not None
+    assert view["kv_cache"].shape == (
+        pool.cfg.max_active_seqs,
+        pool.cfg.ring_size_main,
+        pool.cfg.head_dim,
+    )
+    assert view["kv_cache"].dtype == pool.cfg.dtype
+    # ratio=0 ⇒ no compressor / indexer views
+    assert view["kv_state"] is None
+    assert view["score_state"] is None
+    assert view["indexer_kv"] is None
+
+
+def test_view_for_layer_c4_has_compressor_and_indexer(pool: DSV4KVPool) -> None:
+    """layer_id=1 (compress_ratio=4 in fixture): all four views populated."""
+    view = pool.view_for_layer(layer_id=1)
+    assert view["kv_cache"] is not None
+    assert view["kv_state"] is not None
+    assert view["score_state"] is not None
+    assert view["indexer_kv"] is not None
+    assert view["kv_state"].shape == (
+        pool.cfg.max_active_seqs,
+        pool.cfg.ring_size_compressor,
+        pool.cfg.state_inner_dim,
+    )
+    assert view["indexer_kv"].shape == (
+        pool.cfg.max_active_seqs,
+        pool.cfg.ring_size_indexer,
+        pool.cfg.head_dim,
+    )
+    assert view["kv_state"].dtype == pool.cfg.state_dtype
+    # score_state initialized to -inf per design
+    assert torch.isinf(view["score_state"]).all().item()
+    assert (view["score_state"] < 0).all().item()
+
+
+def test_view_for_layer_c128_has_no_indexer(pool: DSV4KVPool) -> None:
+    """layer_id=5 (compress_ratio=128 in fixture): indexer_kv is None."""
+    view = pool.view_for_layer(layer_id=5)
+    assert view["kv_cache"] is not None
+    assert view["kv_state"] is not None  # c128 has compressor (no overlap)
+    assert view["score_state"] is not None
+    assert view["indexer_kv"] is None
+
+
+def test_view_for_layer_zero_copy(pool: DSV4KVPool) -> None:
+    """Mutating a view writes through to the underlying pool tensor."""
+    view = pool.view_for_layer(layer_id=0)
+    view["kv_cache"][0, 0, 0] = 1.5
+    view2 = pool.view_for_layer(layer_id=0)
+    assert view2["kv_cache"][0, 0, 0].item() == pytest.approx(1.5)
+
+    view_c4 = pool.view_for_layer(layer_id=1)
+    view_c4["kv_state"][0, 0, 0] = 7.25
+    view_c4_again = pool.view_for_layer(layer_id=1)
+    assert view_c4_again["kv_state"][0, 0, 0].item() == pytest.approx(7.25)
+
+
+def test_view_for_layer_out_of_range(pool: DSV4KVPool) -> None:
+    with pytest.raises(IndexError):
+        pool.view_for_layer(layer_id=pool.cfg.num_layers)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+def test_config_rejects_mismatched_ratio_count() -> None:
+    """compress_ratio_per_layer length must equal num_layers."""
+    with pytest.raises(ValueError, match="compress_ratio_per_layer length"):
+        DSV4KVPoolConfig(
+            max_active_seqs=2,
+            num_layers=4,
+            num_c4_layers=1,
+            num_c128_layers=0,
+            head_dim=8,
+            rope_head_dim=4,
+            window_size=16,
+            max_seq_len=128,
+            ring_size_main=16,
+            ring_size_compressor=4,
+            ring_size_indexer=16,
+            # only 3 entries for num_layers=4
+            compress_ratio_per_layer=[0, 4, 0],
+            device=torch.device("cpu"),
+        )
+
+
+def test_config_rejects_inconsistent_c4_count() -> None:
+    """num_c4_layers must match the actual number of ratio==4 entries."""
+    with pytest.raises(ValueError, match="num_c4_layers"):
+        DSV4KVPoolConfig(
+            max_active_seqs=2,
+            num_layers=4,
+            num_c4_layers=2,  # claim 2, but list contains only 1
+            num_c128_layers=0,
+            head_dim=8,
+            rope_head_dim=4,
+            window_size=16,
+            max_seq_len=128,
+            ring_size_main=16,
+            ring_size_compressor=4,
+            ring_size_indexer=16,
+            compress_ratio_per_layer=[0, 4, 0, 0],
+            device=torch.device("cpu"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Optional GPU smoke (skipped on CI runners without GPU)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU not available")
+def test_gpu_smoke_compute_out_cache_loc() -> None:
+    cfg = _make_cfg(max_active_seqs=4, device="cuda")
+    p = DSV4KVPool(cfg)
+    p.admit_request(1)
+    p.admit_request(2)
+    slots = p.get_slots([1, 2])
+    pos = torch.arange(8, dtype=torch.long, device="cuda")
+    cu = torch.tensor([0, 5, 8], dtype=torch.long, device="cuda")
+    out = p.compute_out_cache_loc(pos, slots, cu, ring="main")
+    assert out.device.type == "cuda"
+    assert out.shape == (8,)


### PR DESCRIPTION
## Summary

Implements **W4.2** of the DSV4 multi-request KV-cache reform plan (issue #37, Path 3). This PR introduces the engine-side per-request slot allocator that replaces the W4.1 placeholder ``req_pool_indices = block_tables[:, 0]`` with a stable-unique slot id per active sequence — the fix for the prefix-cache first-block collision the W4.1 runtime gate (``assert_pool_slot_unique``) currently flags at runtime.

**This is a structure-only PR.** No model behavior changes (``atom/models/deepseek_v4.py`` is untouched). Model consumption lands in W4.3, register_buffer migration in W4.4, silicon correctness validation in W4.5.

## What's in the box

- ``atom/engine/__init__.py`` (new)
- ``atom/engine/kv_pool/__init__.py`` (new)
- ``atom/engine/kv_pool/dsv4_pool.py`` (new, 464 LOC) — ``DSV4KVPool`` + ``DSV4KVPoolConfig``:
  - LIFO free-list slot allocator (mirrors ``BlockManager.free_mamba_slots`` at ``atom/model_engine/block_manager.py:215``); idempotent ``admit_request`` / ``finish_request``; ``num_free_slots`` / ``num_active_seqs`` / ``get_slot`` / ``get_slots``.
  - Three logical caches declared per-layer: main sliding-window kv, compressor ``kv_state`` (zero-init) + ``score_state`` (-inf init, fp32), indexer kv (c4-only). Layouts mirror today's model-side ``register_buffer`` shapes so W4.4 can rebind without resizing.
  - ``compute_out_cache_loc(positions, slot_indices, cu_seqlens_q, ring)`` implements the SGLang ``CompressStatePool``-style ring formula ``slot * R + (positions % R)`` with ``torch.bucketize`` segmenting on ``cu_seqlens_q`` (cudagraph-safe). Three rings: ``main`` / ``compressor`` / ``indexer``.
  - ``view_for_layer(layer_id)`` returns zero-copy per-layer dict slices, ready for W4.3 model consumption.
- ``atom/utils/dsv4_forward_batch.py`` (modified, +109/-21):
  - ``from_attn_metadata`` gains optional ``seq_ids`` + ``pool`` kwargs. When both supplied, the W4.1 placeholder is bypassed and ``out_cache_loc`` is populated.
  - Legacy callers without a pool keep the ``block_tables[:, 0]`` fallback + ``assert_pool_slot_unique`` gate (defense in depth, removed in W4.5).
  - New ``from_engine_state(forward_batch_state, pool)`` classmethod for the post-W4.4 clean path.
- ``tests/test_dsv4_pool.py`` (new, 425 LOC) — 22 CPU UTs + 1 optional GPU smoke.

## Test plan

- [x] ``pytest tests/test_dsv4_pool.py tests/test_dsv4_forward_batch.py -v`` => **42 passed** (19 W4.1 UTs untouched + 23 new).
- [x] ``black --target-version py310 --check`` clean across all touched files.
- [x] ``ruff check`` clean across all touched files.
- [x] CPU-only tests pass (per ATOM CI constraint: no GPU required).
- [x] GPU smoke test (``test_gpu_smoke_compute_out_cache_loc``) passes when CUDA is available.

### Coverage highlights

- ``test_prefix_cache_first_block_collision`` — the W4.1 → W4.2 contract: two seqs that would share ``block_tables[:, 0]`` under prefix caching get **different** pool slots.
- Lifecycle: admit-in-range / idempotent-admit / finish-recycles (LIFO order) / finish-unknown-noop / overadmit-raises / get-slot-unknown-raises.
- ``compute_out_cache_loc`` correctness for prefill, decode-lockstep, mixed-batch, all three rings (``main`` / ``compressor`` / ``indexer``), plus ``unknown ring`` rejection.
- ``view_for_layer`` for ratio-0 / ratio-4 / ratio-128 layers, shape + dtype + zero-copy + out-of-range checks.
- Config validation (length and consistency checks on ``compress_ratio_per_layer``).

## Issue / plan references

- Tracks **issue #37** (DSV4 multi-request KV-cache reform) Path 3.
- Predecessor: **W4.1** ``DSV4ForwardBatch`` dataclass (PR #39, commits ``073e77b`` + ``ba3aea3``).
- Design spec: ``/tmp/w42_design.md`` (committed locally; kept as a session artifact).

## Explicit follow-ups (NOT in this PR)

- **W4.2b** — wire ``pool.admit_request`` / ``pool.finish_request`` into ``Scheduler.allocate`` / ``Scheduler.preempt`` / ``Scheduler.postprocess`` (and the kv-connector deferred-free path). Requires resolving design open-question §6.2 (ownership: ``ModelRunner`` vs ``EngineCore`` vs global handle). Gated on ``is_dsv4_arch(config)``.
- **W4.3** — ``atom/models/deepseek_v4.py`` consumes ``forward_batch.kv_pool.view_for_layer(layer_id)`` instead of touching its own ``register_buffer`` rows; replaces the in-process FBID→row dict at ``deepseek_v4.py:285-370``.
- **W4.4** — drop ``register_buffer`` declarations on the model side entirely; switch the runtime to ``DSV4ForwardBatch.from_engine_state`` exclusively (and remove the ``block_tables[:, 0]`` fallback + ``assert_pool_slot_unique`` gate).
- **W4.5** — silicon correctness validation at conc=4 (lm_eval gsm8k / hellaswag).

## Open design questions flagged for review

(See ``/tmp/w42_design.md`` §6 for full discussion.)

1. **``seq_ids`` not on ``AttentionMetaData`` today.** The current PR threads ``seq_ids`` through as an explicit kwarg on ``from_attn_metadata`` so this PR doesn't need to widen ``AttentionMetaData``. W4.2b/W4.3 will decide whether to (a) add ``attn_metadata.seq_ids`` (small scope) or (b) route everything through ``from_engine_state`` (cleaner, larger blast radius).
2. **Pool ownership.** The pool is currently constructed independently. W4.2b needs to decide between (a) attaching it to ``ModelRunner.dsv4_pool``, (b) a global singleton like ``set_kv_cache_data``, or (c) a thin handle on ``EngineCore`` co-owned with the Scheduler.
3. **TP > 1 cross-rank slot agreement.** Same Scheduler ⇒ same slot map ⇒ no broadcast needed. Cross-process Scheduler split (if introduced) would require a slot-map broadcast — covered by an explicit UT once the design lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)