### PR TITLE
[Hotfix] DSV4 warmup HSA crash — skip W4 path on dummy_run

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1868,6 +1868,17 @@ class ModelRunner:
         if not self._is_dsv4_model():
             return None, None
 
+        # Hotfix (issue #37 W4.5 silicon evidence): warmup runs a dummy
+        # MAX_BATCHED_TOKENS-sized forward to allocate workspaces. Routing
+        # warmup through the W4 (multi-request) path triggers an HSA
+        # exception 0x1016 in sparse_attn / KV-scatter kernels because the
+        # dummy seq_lens / positions don't match the pool's slot-mapping
+        # contract. Skip W4 entirely on dummy runs — the legacy single-
+        # request fallback in deepseek_v4.py handles warmup zeros tensors
+        # correctly.
+        if batch is not None and getattr(batch, "is_dummy_run", False):
+            return None, None
+
         if not hasattr(self, "_dsv4_pool") or self._dsv4_pool is None:
             self._dsv4_pool = self._build_dsv4_pool()
 


### PR DESCRIPTION
## Summary

Hotfix for the silicon HSA exception 0x1016 introduced by PR #42 (W4.3) when DSV4 warmup runs through the new W4 multi-request path. Single-line guard in `_maybe_setup_dsv4_forward_batch` to skip W4 setup on `batch.is_dummy_run`.

## Silicon evidence (Evidence I)

Right after #42 merged, ran the conc=4 4-prompt smoke harness on MI355 TP=8:

```
[atom 00:35:44-56] Model load done (all 8 ranks)
[atom 00:35:56] DSV4 KV pool created (all 8 ranks)
[atom 00:35:57] WARMUP forward → HSA_STATUS_ERROR_EXCEPTION code 0x1016 → all 8 ranks abort
[atom 00:35:58] EngineCore SHUTDOWN signal during initialization
```

No user prompt was processed; crash was during the warmup `dummy_batch` forward.

## Root cause

`_maybe_setup_dsv4_forward_batch` (added in PR #42) admits warmup dummy seqs into `DSV4KVPool` and builds a `DSV4ForwardBatch` from warmup `attn_metadata`. Warmup batches are sized for MAX_BATCHED_TOKENS with synthetic positions / seq_lens that don't match the pool's slot-mapping contract. The model's W4 path runs sparse_attn / KV scatter and the AITER kernel hits an out-of-bounds memory access.

## Fix

```python
if batch is not None and getattr(batch, "is_dummy_run", False):
    return None, None
```

Warmup falls through to the legacy single-request path (preserved by W4.3 sub-agent) — the same path PR-X / PR #36 / PR #41 successfully bring up DSV4 with. Real requests (`is_dummy_run=False`) still get the W4 path.

## Test plan

- [x] Lint clean: `ruff check atom/model_engine/model_runner.py` — passed; `black --check` — unchanged
- [ ] Silicon retry on MI355 with the same 4-prompt smoke harness — to be added as Evidence I in #37 once gating CI green
- [ ] Single-request gsm8k limit=20 to confirm 70% baseline (Evidence F) preserved

## Out of scope

- Validating that W4 path itself produces correct multi-request output. That's the W4.5 owner gate — separate validation PR after this hotfix unblocks the warmup path.
- W4.4 Compressor / Indexer state migration (in flight on a separate branch).

## References

- #37 W4.5 silicon evidence
- #42 PR #42 introduced the gap
- #41 W4.2 pool itself works (no warmup interaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)