### PR TITLE
[W4.3-redo] Scheduler lifecycle event registry (#37 Task 8)

### DIFF
--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -397,6 +397,40 @@ class Scheduler:
 
         self.kv_connector = get_kvconnector("scheduler", config)
 
+        # W4.3 (issue #37 P2.2): seq lifecycle event registry. ModelRunner
+        # subscribes its KV pool admit/finish methods here. Scheduler is
+        # pool-agnostic — it must not import or reference any concrete pool.
+        self._admit_listeners: list = []
+        self._finish_listeners: list = []
+
+    def register_admit_listener(self, fn) -> None:
+        """Subscribe a callable(seq_id: int) -> None to be invoked on admit.
+
+        Used by ModelRunner to wire pool admit_request without leaking
+        pool dependencies into the scheduler.
+        """
+        self._admit_listeners.append(fn)
+
+    def register_finish_listener(self, fn) -> None:
+        """Subscribe a callable(seq_id: int) -> None to be invoked on finish/preempt."""
+        self._finish_listeners.append(fn)
+
+    def _emit_admit(self, seq_id: int) -> None:
+        for listener in self._admit_listeners:
+            try:
+                listener(seq_id)
+            except Exception as e:
+                logger.warning("Seq admit listener %s raised %s; ignoring", listener, e)
+
+    def _emit_finish(self, seq_id: int) -> None:
+        for listener in self._finish_listeners:
+            try:
+                listener(seq_id)
+            except Exception as e:
+                logger.warning(
+                    "Seq finish listener %s raised %s; ignoring", listener, e
+                )
+
     def is_finished(self):
         return not self.waiting and not self.running
 
@@ -467,6 +501,7 @@ class Scheduler:
                 seq.status = SequenceStatus.RUNNING
                 seq.is_first_decode = True
                 self.running.append(seq)
+                self._emit_admit(seq.id)
                 continue
 
             num_seqs_prefill += 1
@@ -479,6 +514,7 @@ class Scheduler:
             self.running.append(seq)
             scheduled_seqs[seq.id] = seq
             num_scheduled_tokens.append(num_new_tokens)
+            self._emit_admit(seq.id)
 
         if skipped_waiting_requests:
             logger.debug(
@@ -577,6 +613,8 @@ class Scheduler:
         seq.spec_token_ids = np.array([], dtype=np.int32)
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
+        # Notify lifecycle subscribers: seq is no longer running.
+        self._emit_finish(seq.id)
 
     def postprocess(
         self,
@@ -729,6 +767,8 @@ class Scheduler:
             else:
                 self.block_manager.deallocate(seq)
             self.running.remove(seq)
+            # Notify lifecycle subscribers: seq has finished.
+            self._emit_finish(seq.id)
         return finished_seqs
 
     def _update_waiting_for_remote_kv(self, seq: Sequence) -> bool:

--- a/tests/test_scheduler_lifecycle_events.py
+++ b/tests/test_scheduler_lifecycle_events.py
@@ -1,0 +1,64 @@
+"""Scheduler emits seq lifecycle events via callback registry (issue #37 W4.3 P2.2).
+
+Establishes the ownership boundary: Scheduler does not know DSV4KVPool
+exists; ModelRunner subscribes pool.admit_request / pool.finish_request
+to these events.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestEventRegistry:
+    def test_admit_listener_registry_exists(self, scheduler):
+        """Public API: register_admit_listener(fn) appends fn to the registry."""
+        listener = MagicMock()
+        scheduler.register_admit_listener(listener)
+        assert listener in scheduler._admit_listeners
+
+    def test_finish_listener_registry_exists(self, scheduler):
+        listener = MagicMock()
+        scheduler.register_finish_listener(listener)
+        assert listener in scheduler._finish_listeners
+
+    def test_emit_admit_calls_all_admit_listeners(self, scheduler):
+        l1, l2 = MagicMock(), MagicMock()
+        scheduler.register_admit_listener(l1)
+        scheduler.register_admit_listener(l2)
+        scheduler._emit_admit(seq_id=42)
+        l1.assert_called_once_with(42)
+        l2.assert_called_once_with(42)
+
+    def test_emit_finish_calls_all_finish_listeners(self, scheduler):
+        l1, l2 = MagicMock(), MagicMock()
+        scheduler.register_finish_listener(l1)
+        scheduler.register_finish_listener(l2)
+        scheduler._emit_finish(seq_id=99)
+        l1.assert_called_once_with(99)
+        l2.assert_called_once_with(99)
+
+    def test_listener_exception_does_not_propagate(self, scheduler):
+        """A bad listener cannot break the scheduler."""
+        bad = MagicMock(side_effect=RuntimeError("oops"))
+        good = MagicMock()
+        scheduler.register_admit_listener(bad)
+        scheduler.register_admit_listener(good)
+        # Must not raise
+        scheduler._emit_admit(seq_id=1)
+        good.assert_called_once_with(1)
+
+
+class TestNoDsv4PoolImport:
+    def test_scheduler_source_does_not_reference_dsv4_pool(self):
+        """Ownership boundary check: scheduler.py must not import DSV4KVPool.
+
+        ModelRunner subscribes the pool's admit/finish methods to the
+        scheduler's events. The scheduler itself is pool-agnostic.
+        """
+        import atom.model_engine.scheduler as sched_mod
+
+        with open(sched_mod.__file__) as f:
+            src = f.read()
+        # The scheduler may have generic listener bookkeeping but must not
+        # know about DSV4KVPool specifically.
+        assert "DSV4KVPool" not in src
+        assert "dsv4_pool" not in src.lower()


### PR DESCRIPTION
## Summary

Adds a generic seq-lifecycle event registry to `Scheduler` so `ModelRunner` can wire its per-TP KV pool admit/finish without leaking pool dependencies upstream.

Spec ownership boundary (Section 3, issue #37 W4.3 P2.2): ModelRunner owns the pool per TP rank; Scheduler emits seq lifecycle events; the pool receives lifecycle ops only from ModelRunner. The scheduler must never import or reference any concrete pool class.

## What

- `Scheduler.register_admit_listener(fn)` / `register_finish_listener(fn)` public APIs
- `_emit_admit(seq_id)` / `_emit_finish(seq_id)` internal emit helpers
- `_emit_admit` wired at both admit sites in `schedule()`:
  - normal prefill admit (after `self.running.append(seq)`)
  - WAITING_FOR_REMOTE_KVS -> RUNNING transition
- `_emit_finish` wired at both finish/preempt sites:
  - `preempt(seq)` (after dealloc + waiting re-queue)
  - `postprocess()` finished-seqs loop (after `self.running.remove(seq)`)
- Listener exceptions caught + logged at WARNING; cannot break scheduling
- Scheduler source remains pool-agnostic (test asserts no `DSV4KVPool` / `dsv4_pool` strings)

## Test plan

- [x] 6 new unit tests in `tests/test_scheduler_lifecycle_events.py` (registry, emit, exception isolation, no-pool-import boundary check)
- [x] All 29 existing scheduler tests still pass (35 total green)
- [x] `ruff check` + `black --check` clean

## References

- sunway513/atom#37 W4.3 P2.2 ownership boundary
- Spec docs/superpowers/specs/2026-04-26-dsv4-w43-redo-aiter-track-design.md Section 3

Generated with [Claude Code](https://claude.com/claude-code)