### PR TITLE
[W4.3-redo] ModelRunner pool ownership + is_dummy_run gate (#37 Task 9)

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1748,6 +1748,164 @@ class ModelRunner:
         num_input_tokens = int(torch.max(num_tokens_across_dp).item())
         return num_input_tokens, num_tokens_across_dp, reqs_across_dp
 
+    # ------------------------------------------------------------------
+    # DSV4 W4 path helpers (issue sunway513/atom#37 P2.2 — W4.3-redo Task 9)
+    # ------------------------------------------------------------------
+
+    def _is_dsv4_model(self) -> bool:
+        """Detect DSV4 architectures from ``hf_config.architectures``.
+
+        Centralized so callers don't sprinkle string comparisons across
+        the codebase. Mirrors the multi-request guard used in
+        ``atom.utils.dsv4_guard``.
+        """
+        archs = getattr(self.config.hf_config, "architectures", None) or []
+        from atom.utils.dsv4_guard import is_dsv4_arch
+
+        return is_dsv4_arch(archs)
+
+    def _maybe_setup_dsv4_forward_batch(self, batch, attn_metadata, positions):
+        """W4.3-redo (issue #37): lazy-init pool, admit slots, build DSV4ForwardBatch.
+
+        Critical contract: ``is_dummy_run`` short-circuit at the VERY
+        entry. Warmup runs ``MAX_BATCHED_TOKENS``-sized synthetic tensors
+        that crash the W4 path with HSA exception 0x1016 (#37 Evidence
+        I / I' / I''). Only safe behavior is to fall through to the
+        legacy single-request path by returning ``(None, None)``.
+
+        Also short-circuits if ``ATOM_DSV4_USE_W4_PATH`` is unset — pool
+        allocation is harmless but admitting seqs without the flag would
+        leak slots and reorder kernels under the wrong feature gate.
+
+        Returns
+        -------
+        ``(pool, forward_batch)`` — both ``None`` if W4 path is not
+        active for this step, so callers can pass straight to
+        ``set_forward_context`` without further branching.
+        """
+        if not self._is_dsv4_model():
+            return None, None
+
+        # CRITICAL: must be first check after arch detection. This is the
+        # canonical fix for issue #42 — warmup synthetic tensors must NOT
+        # enter the W4 path.
+        if batch is not None and getattr(batch, "is_dummy_run", False):
+            return None, None
+
+        from atom.utils import envs
+
+        if not envs.ATOM_DSV4_USE_W4_PATH:
+            return None, None
+
+        if getattr(self, "_dsv4_pool", None) is None:
+            self._dsv4_pool = self._build_dsv4_pool()
+
+        # Admit any seqs in this batch the pool hasn't seen yet. Idempotent
+        # under re-admit (DSV4KVPool.admit_request returns the same slot).
+        seq_ids: list[int] = []
+        if batch is not None:
+            seq_ids = list(batch.req_ids)
+            for sid in seq_ids:
+                self._dsv4_pool.admit_request(sid)
+
+        forward_batch = None
+        if attn_metadata is not None and positions is not None:
+            try:
+                from atom.utils.dsv4_forward_batch import DSV4ForwardBatch
+
+                forward_batch = DSV4ForwardBatch.from_attn_metadata(
+                    attn_metadata,
+                    positions,
+                    seq_ids=seq_ids if seq_ids else None,
+                    pool=self._dsv4_pool,
+                )
+            except Exception as e:
+                logger.warning(
+                    "DSV4: failed to build ForwardBatch (%s); "
+                    "falling back to legacy path",
+                    e,
+                )
+                forward_batch = None
+
+        return self._dsv4_pool, forward_batch
+
+    def _build_dsv4_pool(self):
+        """Allocate a DSV4KVPool sized from the loaded model.
+
+        Reads layer count, head dim, window size, compress ratios, etc.
+        from the model's ``DeepseekV4Args`` dataclass. One pool per
+        ModelRunner = one per TP rank. If the runner has access to a
+        scheduler instance (``self.scheduler``), subscribes
+        ``pool.finish_request`` to the scheduler's finish-listener
+        registry — this is the P2.2 ownership boundary: the scheduler
+        stays pool-agnostic and the pool stays unaware of seq lifecycle
+        events except through the registered listener.
+        """
+        from atom.engine.kv_pool.dsv4_pool import DSV4KVPool, DSV4KVPoolConfig
+
+        args = self.model.args  # DeepseekV4Args
+
+        # Per-layer compress ratios. Prefer the canonical ``compress_ratios``
+        # tuple on DeepseekV4Args; fall back to an alternating 4/128 default
+        # for synthetic test models that don't populate it.
+        n_layers = args.n_layers
+        compress_ratios = getattr(args, "compress_ratios", ()) or ()
+        compress_ratio_per_layer: list[int] = []
+        for layer_idx in range(n_layers):
+            if layer_idx < len(compress_ratios):
+                r = int(compress_ratios[layer_idx])
+            else:
+                r = 128 if layer_idx % 2 == 0 else 4
+            compress_ratio_per_layer.append(r)
+        n_c4 = sum(1 for r in compress_ratio_per_layer if r == 4)
+        n_c128 = sum(1 for r in compress_ratio_per_layer if r == 128)
+
+        # Ring sizes mirror SGLang's get_compress_state_ring_size (4→8, 128→128).
+        ring_size_compressor = 2 * 4
+        ring_size_indexer = 2 * 64
+        ring_size_main = max(getattr(args, "window_size", 128), 64)
+
+        cfg = DSV4KVPoolConfig(
+            max_active_seqs=self.config.max_num_seqs,
+            num_layers=n_layers,
+            num_c4_layers=n_c4,
+            num_c128_layers=n_c128,
+            head_dim=args.head_dim,
+            rope_head_dim=getattr(args, "rope_head_dim", args.head_dim // 2),
+            window_size=getattr(args, "window_size", 128),
+            max_seq_len=getattr(args, "max_seq_len", 4096),
+            ring_size_main=ring_size_main,
+            ring_size_compressor=ring_size_compressor,
+            ring_size_indexer=ring_size_indexer,
+            compress_ratio_per_layer=compress_ratio_per_layer,
+            dtype=self.config.torch_dtype,
+            device=self.device,
+        )
+        pool = DSV4KVPool(cfg)
+
+        # P2.2 ownership boundary: subscribe pool's finish_request to the
+        # scheduler's finish events when one is reachable from the runner.
+        # In ATOM today the scheduler lives in EngineCore (parent process)
+        # while ModelRunner runs in a child process, so this branch is a
+        # no-op in production; it exists for in-process integration tests
+        # that hand a scheduler reference to the runner. The wiring shape
+        # is the canonical one — Scheduler stays pool-agnostic.
+        scheduler = getattr(self, "scheduler", None)
+        if scheduler is not None and hasattr(scheduler, "register_finish_listener"):
+            scheduler.register_finish_listener(pool.finish_request)
+
+        logger.info(
+            "DSV4 KV pool: n_layers=%d c4=%d c128=%d max_active_seqs=%d "
+            "window=%d device=%s",
+            n_layers,
+            n_c4,
+            n_c128,
+            cfg.max_active_seqs,
+            cfg.window_size,
+            cfg.device,
+        )
+        return pool
+
     def prepare_inputs(self, batch: ScheduledBatch, input_ids: torch.Tensor = None):
         is_prefill = batch.total_tokens_num_prefill > 0
         bs = batch.total_seqs_num
@@ -1812,6 +1970,14 @@ class ModelRunner:
             reqs_across_dp,
         )
 
+        # W4.3-redo (issue #37 P2.2): set up DSV4 W4-path pool + ForwardBatch
+        # if and only if (a) model is DSV4, (b) batch is not a dummy warmup,
+        # and (c) ATOM_DSV4_USE_W4_PATH is enabled. Returns (None, None)
+        # otherwise so the legacy single-request fallback path runs.
+        dsv4_pool, dsv4_forward_batch = self._maybe_setup_dsv4_forward_batch(
+            batch, attn_metadata, positions
+        )
+
         set_forward_context(
             attn_metadata=attn_metadata,
             atom_config=self.config,
@@ -1820,6 +1986,8 @@ class ModelRunner:
             num_tokens_across_dp=num_tokens_across_dp,
             spec_decode_metadata=spec_decode_metadata,
             ubatch_slices=ubatch_slices,
+            dsv4_pool=dsv4_pool,
+            dsv4_forward_batch=dsv4_forward_batch,
         )
         return graph_bs
 

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -397,6 +397,40 @@ class Scheduler:
 
         self.kv_connector = get_kvconnector("scheduler", config)
 
+        # W4.3 (issue #37 P2.2): seq lifecycle event registry. ModelRunner
+        # subscribes its KV pool admit/finish methods here. Scheduler is
+        # pool-agnostic — it must not import or reference any concrete pool.
+        self._admit_listeners: list = []
+        self._finish_listeners: list = []
+
+    def register_admit_listener(self, fn) -> None:
+        """Subscribe a callable(seq_id: int) -> None to be invoked on admit.
+
+        Used by ModelRunner to wire pool admit_request without leaking
+        pool dependencies into the scheduler.
+        """
+        self._admit_listeners.append(fn)
+
+    def register_finish_listener(self, fn) -> None:
+        """Subscribe a callable(seq_id: int) -> None to be invoked on finish/preempt."""
+        self._finish_listeners.append(fn)
+
+    def _emit_admit(self, seq_id: int) -> None:
+        for listener in self._admit_listeners:
+            try:
+                listener(seq_id)
+            except Exception as e:
+                logger.warning("Seq admit listener %s raised %s; ignoring", listener, e)
+
+    def _emit_finish(self, seq_id: int) -> None:
+        for listener in self._finish_listeners:
+            try:
+                listener(seq_id)
+            except Exception as e:
+                logger.warning(
+                    "Seq finish listener %s raised %s; ignoring", listener, e
+                )
+
     def is_finished(self):
         return not self.waiting and not self.running
 
@@ -467,6 +501,7 @@ class Scheduler:
                 seq.status = SequenceStatus.RUNNING
                 seq.is_first_decode = True
                 self.running.append(seq)
+                self._emit_admit(seq.id)
                 continue
 
             num_seqs_prefill += 1
@@ -479,6 +514,7 @@ class Scheduler:
             self.running.append(seq)
             scheduled_seqs[seq.id] = seq
             num_scheduled_tokens.append(num_new_tokens)
+            self._emit_admit(seq.id)
 
         if skipped_waiting_requests:
             logger.debug(
@@ -577,6 +613,8 @@ class Scheduler:
         seq.spec_token_ids = np.array([], dtype=np.int32)
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
+        # Notify lifecycle subscribers: seq is no longer running.
+        self._emit_finish(seq.id)
 
     def postprocess(
         self,
@@ -729,6 +767,8 @@ class Scheduler:
             else:
                 self.block_manager.deallocate(seq)
             self.running.remove(seq)
+            # Notify lifecycle subscribers: seq has finished.
+            self._emit_finish(seq.id)
         return finished_seqs
 
     def _update_waiting_for_remote_kv(self, seq: Sequence) -> bool:

--- a/atom/utils/dsv4_guard.py
+++ b/atom/utils/dsv4_guard.py
@@ -35,12 +35,16 @@ def validate_dsv4_multireq(architectures: list[str], max_num_seqs: int) -> None:
     engine-owned KV pools, branch `feat/dsv4-forward-batch-paged-kv`).
 
     Until W4 lands, refuse multi-request configs to prevent silently-
-    broken output. The `ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1` env override
-    exists for kernel-level perf experiments where output correctness
-    is not being measured.
+    broken output. Bypass requires **double opt-in** (W4.3 amendment,
+    PR #46 P1.1 review fix): BOTH `ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1`
+    AND `ATOM_DSV4_USE_W4_PATH=1` must be set together. Either alone
+    rejects, because `UNSAFE_MULTIREQ_DEV=1` without the W4 path opt-in
+    would route through the legacy (broken) multi-request path that
+    crashed PR #42 with HSA exception 0x1016.
 
     Raises:
-        ValueError: when DSV4 + max_num_seqs > 1 + override unset.
+        ValueError: when DSV4 + max_num_seqs > 1 + double opt-in
+            unsatisfied (either flag missing).
     """
     if not is_dsv4_arch(architectures):
         return
@@ -48,15 +52,24 @@ def validate_dsv4_multireq(architectures: list[str], max_num_seqs: int) -> None:
         return
     from atom.utils import envs
 
-    if envs.ATOM_DSV4_UNSAFE_MULTIREQ_DEV:
-        return
-    raise ValueError(
-        "DSV4 architectures currently support only "
-        f"max_num_seqs=1 (got max_num_seqs={max_num_seqs}). "
-        "Multi-request support is in development on the W4 branch "
-        "(feat/dsv4-forward-batch-paged-kv); see "
-        "https://github.com/sunway513/ATOM/issues/37 for context. "
-        "To bypass this guard for kernel-level perf experiments "
-        "where output correctness is NOT being measured, set "
-        "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1."
-    )
+    unsafe = envs.ATOM_DSV4_UNSAFE_MULTIREQ_DEV
+    use_w4 = envs.ATOM_DSV4_USE_W4_PATH
+
+    if not unsafe:
+        raise ValueError(
+            "DSV4 architectures currently support only "
+            f"max_num_seqs=1 (got max_num_seqs={max_num_seqs}). "
+            "Multi-request support is in development on the W4 branch; "
+            "see https://github.com/sunway513/ATOM/issues/37. To bypass "
+            "this guard for kernel-level perf experiments where output "
+            "correctness is NOT being measured, set BOTH "
+            "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1 AND ATOM_DSV4_USE_W4_PATH=1."
+        )
+    if not use_w4:
+        raise ValueError(
+            "DSV4 multi-request requires ATOM_DSV4_USE_W4_PATH=1 to opt "
+            "into the W4 path. ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1 alone "
+            "would route through the legacy (broken) multi-request "
+            "path. See issue #37."
+        )
+    # Both flags set → allow

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -105,6 +105,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": lambda: (
         os.getenv("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", "0") == "1"
     ),
+    # --- DSV4 W4.3-redo flags (issue #37) ---
+    # Enable the W4 multi-request path. When 0 (default), DSV4 single-request
+    # legacy path runs unchanged. Task 7 amends the Path 2 guard to require
+    # this flag together with ATOM_DSV4_UNSAFE_MULTIREQ_DEV before allowing
+    # max_num_seqs > 1.
+    "ATOM_DSV4_USE_W4_PATH": lambda: (os.getenv("ATOM_DSV4_USE_W4_PATH", "0") == "1"),
+    # Enable host-side AITER ABI validator before each sparse_attn call.
+    # Zero prod overhead when off.
+    "ATOM_AITER_VALIDATE": lambda: (os.getenv("ATOM_AITER_VALIDATE", "0") == "1"),
 }
 
 

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -329,6 +329,16 @@ class ForwardContext:
 
     ubatch_slices: Optional[list[Any]] = None
 
+    # W4.3-redo (issue #37 P2.2): the per-step DSV4 KV pool + ForwardBatch.
+    # Both fields stay ``None`` for non-DSV4 models, for DSV4 in legacy single-
+    # request fallback, and for the warmup ``is_dummy_run`` path. Models read
+    # ``dsv4_forward_batch`` to dispatch into the W4 multi-request kernel chain
+    # and ``dsv4_pool`` if they need direct slot lookups (typed as ``Any`` to
+    # avoid a circular import on ``DSV4KVPool`` / ``DSV4ForwardBatch``).
+    dsv4_pool: Optional[Any] = None
+
+    dsv4_forward_batch: Optional[Any] = None
+
     def __post_init__(self):
         if not hasattr(self, "no_compile_layers") or self.no_compile_layers is None:
             self.no_compile_layers = {}
@@ -366,6 +376,8 @@ def set_forward_context(
     num_tokens_across_dp: Optional[torch.Tensor] = None,
     spec_decode_metadata: Optional[SpecDecodeMetadata] = None,
     ubatch_slices: Optional[list[Any]] = None,
+    dsv4_pool: Optional[Any] = None,
+    dsv4_forward_batch: Optional[Any] = None,
 ) -> None:
     global _forward_context
     dp_metadata: Optional[DPMetadata] = None
@@ -385,6 +397,8 @@ def set_forward_context(
         dp_metadata=dp_metadata,
         spec_decode_metadata=spec_decode_metadata,
         ubatch_slices=ubatch_slices,
+        dsv4_pool=dsv4_pool,
+        dsv4_forward_batch=dsv4_forward_batch,
     )  # _forward_context.attn_metadata = attn_metadata
     # _forward_context.no_compile_layers = atom_config.compilation_config.static_forward_context
     # _forward_context = ForwardContext(no_compile_layers=atom_config.compilation_config.static_forward_context, attn_metadata=attn_metadata)

--- a/tests/test_dsv4_multireq_guard.py
+++ b/tests/test_dsv4_multireq_guard.py
@@ -69,13 +69,65 @@ class TestValidateDsv4Multireq:
         _validate_dsv4_multireq(architectures=["DeepseekV4ForCausalLM"], max_num_seqs=1)
 
     def test_dsv4_arch_with_override_accepts_max_num_seqs_4(self):
-        with patch.dict(os.environ, {"ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1"}):
+        # Post-W4.3 spec: BOTH flags required (double opt-in).
+        with patch.dict(
+            os.environ,
+            {
+                "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1",
+                "ATOM_DSV4_USE_W4_PATH": "1",
+            },
+        ):
             # Re-import envs so the lazy lambda re-reads os.environ.
             import importlib
 
             from atom.utils import envs as envs_mod
 
             importlib.reload(envs_mod)
+            _validate_dsv4_multireq(
+                architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+            )
+
+    def test_unsafe_alone_now_rejects(self):
+        """Post-W4.3 spec: UNSAFE=1 alone is no longer enough — also need USE_W4_PATH=1."""
+        with patch.dict(os.environ, {"ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1"}):
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            with pytest.raises(ValueError, match="ATOM_DSV4_USE_W4_PATH"):
+                _validate_dsv4_multireq(
+                    architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+                )
+
+    def test_use_w4_alone_rejects(self):
+        with patch.dict(os.environ, {"ATOM_DSV4_USE_W4_PATH": "1"}):
+            os.environ.pop("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            with pytest.raises(ValueError, match="ATOM_DSV4_UNSAFE_MULTIREQ_DEV"):
+                _validate_dsv4_multireq(
+                    architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+                )
+
+    def test_both_flags_allow_multireq(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1",
+                "ATOM_DSV4_USE_W4_PATH": "1",
+            },
+        ):
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            # Should not raise
             _validate_dsv4_multireq(
                 architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
             )
@@ -107,14 +159,15 @@ class TestValidateDsv4Multireq:
     def test_error_message_points_users_to_remediation(self):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", None)
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
             with pytest.raises(ValueError) as exc_info:
                 _validate_dsv4_multireq(
                     architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
                 )
             msg = str(exc_info.value)
             assert "issues/37" in msg
-            assert "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1" in msg
-            assert "feat/dsv4-forward-batch-paged-kv" in msg
+            assert "ATOM_DSV4_UNSAFE_MULTIREQ_DEV" in msg
+            assert "ATOM_DSV4_USE_W4_PATH" in msg
 
 
 class TestConfigIntegration:

--- a/tests/test_dsv4_multireq_guard.py
+++ b/tests/test_dsv4_multireq_guard.py
@@ -193,3 +193,32 @@ class TestDSV4UnsafeMultireqDevEnv:
 
             importlib.reload(envs_mod)
             assert envs_mod.ATOM_DSV4_UNSAFE_MULTIREQ_DEV is False
+
+    def test_use_w4_path_default_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_DSV4_USE_W4_PATH is False
+
+    def test_use_w4_path_set_true(self):
+        with patch.dict(os.environ, {"ATOM_DSV4_USE_W4_PATH": "1"}):
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_DSV4_USE_W4_PATH is True
+
+    def test_aiter_validate_default_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ATOM_AITER_VALIDATE", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_AITER_VALIDATE is False

--- a/tests/test_modelrunner_dsv4_pool_lifecycle.py
+++ b/tests/test_modelrunner_dsv4_pool_lifecycle.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""ModelRunner is the sole owner of DSV4KVPool (issue sunway513/atom#37 P2.2).
+
+Verifies the canonical #42 fix: ``is_dummy_run`` short-circuit at the very
+entry of ``_maybe_setup_dsv4_forward_batch`` + ``ATOM_DSV4_USE_W4_PATH``
+gate. Both must pass before the pool is touched.
+
+Additionally validates:
+- pool finish_request is idempotent under preempt-then-finish race.
+- ModelRunner._build_dsv4_pool wires the pool's finish_request into
+  the scheduler's finish-listener registry (P2.2 ownership boundary).
+
+These tests do NOT exercise live cudagraph or real model construction;
+they exercise the pure pool-lifecycle helper using ``unittest.mock``.
+
+Heavy aiter / model-loader imports at the top of ``model_runner.py`` are
+stubbed below so the module is importable without GPU dependencies.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-import: stub the heavy chain that atom.model_engine.model_runner pulls
+# in at module level (aiter, model_loader, kv_transfer, etc.).
+# Must run before any `from atom.model_engine.model_runner import ModelRunner`.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    return sys.modules[name]
+
+
+def _stub_modelrunner_imports() -> None:
+    # aiter top-level: model_runner does
+    #   from aiter import destroy_dist_env, dtypes, init_dist_env
+    _aiter = _ensure_module("aiter")
+    for fn in ("destroy_dist_env", "init_dist_env"):
+        if not hasattr(_aiter, fn):
+            setattr(_aiter, fn, lambda *a, **kw: None)
+    if not hasattr(_aiter, "dtypes"):
+        _aiter.dtypes = types.SimpleNamespace()
+
+    # aiter.dist.parallel_state — extra symbols beyond conftest's stubs.
+    _ps = _ensure_module("aiter.dist.parallel_state")
+    for fn in ("get_dp_group", "get_pp_group", "get_tp_group", "graph_capture"):
+        if not hasattr(_ps, fn):
+            setattr(_ps, fn, lambda *a, **kw: None)
+
+    # aiter.dist.utils — get_distributed_init_method
+    _du = _ensure_module("aiter.dist.utils")
+    if not hasattr(_du, "get_distributed_init_method"):
+        _du.get_distributed_init_method = lambda *a, **kw: ""
+
+    # atom.model_loader.loader — load_model
+    _ml_pkg = _ensure_module("atom.model_loader")
+    _ml_pkg.__path__ = []
+    _ml = _ensure_module("atom.model_loader.loader")
+    if not hasattr(_ml, "load_model"):
+        _ml.load_model = lambda *a, **kw: None
+
+    # atom.model_ops.* — RejectionSampler, sampler, etc.
+    _mo_pkg = _ensure_module("atom.model_ops")
+    _mo_pkg.__path__ = []
+    _rj = _ensure_module("atom.model_ops.rejection_sampler")
+    if not hasattr(_rj, "RejectionSampler"):
+        _rj.RejectionSampler = type("RejectionSampler", (), {})
+    _sm = _ensure_module("atom.model_ops.sampler")
+    if not hasattr(_sm, "SAMPLER_EPS"):
+        _sm.SAMPLER_EPS = 1e-6
+    if not hasattr(_sm, "Sampler"):
+        _sm.Sampler = type("Sampler", (), {})
+
+    # atom.spec_decode.eagle — EagleProposer
+    _sd_pkg = _ensure_module("atom.spec_decode")
+    _sd_pkg.__path__ = []
+    _ea = _ensure_module("atom.spec_decode.eagle")
+    if not hasattr(_ea, "EagleProposer"):
+        _ea.EagleProposer = type("EagleProposer", (), {})
+
+    # atom.kv_transfer.disaggregation — KVConnectorOutput
+    _kt_pkg = _ensure_module("atom.kv_transfer")
+    _kt_pkg.__path__ = []
+    _dg = _ensure_module("atom.kv_transfer.disaggregation")
+    if not hasattr(_dg, "KVConnectorOutput"):
+        _dg.KVConnectorOutput = type("KVConnectorOutput", (), {})
+
+    # atom.utils submodules used by model_runner
+    _u_pkg = _ensure_module("atom.utils")
+    _u_pkg.__path__ = [
+        __import__("os").path.join(
+            __import__("os").path.dirname(__import__("os").path.dirname(__file__)),
+            "atom",
+            "utils",
+        )
+    ]
+    # tbo, selector — stub to avoid heavy chain
+    _tbo = _ensure_module("atom.utils.tbo")
+    if not hasattr(_tbo, "UBatchWrapper"):
+        _tbo.UBatchWrapper = type("UBatchWrapper", (), {})
+    if not hasattr(_tbo, "maybe_create_ubatch_slices"):
+        _tbo.maybe_create_ubatch_slices = lambda *a, **kw: None
+    _sel = _ensure_module("atom.utils.selector")
+    if not hasattr(_sel, "get_attn_backend"):
+        _sel.get_attn_backend = lambda *a, **kw: None
+
+    # atom.config — extra symbol set_current_atom_config
+    _cfg = sys.modules.get("atom.config")
+    if _cfg is not None and not hasattr(_cfg, "set_current_atom_config"):
+        _cfg.set_current_atom_config = lambda *a, **kw: None
+
+    # atom.utils.__init__ — model_runner does
+    #   from atom.utils import (CpuGpuBuffer, envs, get_hf_text_config,
+    #       init_exit_handler, resolve_obj_by_qualname)
+    if not hasattr(_u_pkg, "CpuGpuBuffer"):
+        _u_pkg.CpuGpuBuffer = type("CpuGpuBuffer", (), {})
+    if not hasattr(_u_pkg, "envs"):
+        from atom.utils import envs as _envs
+
+        _u_pkg.envs = _envs
+    if not hasattr(_u_pkg, "get_hf_text_config"):
+        _u_pkg.get_hf_text_config = lambda cfg: cfg
+    if not hasattr(_u_pkg, "init_exit_handler"):
+        _u_pkg.init_exit_handler = lambda *a, **kw: None
+    if not hasattr(_u_pkg, "resolve_obj_by_qualname"):
+        _u_pkg.resolve_obj_by_qualname = lambda name: None
+    # graph_marker referenced by model_runner.__init__
+    _gm = _ensure_module("atom.utils.graph_marker")
+    if not hasattr(_gm, "set_graph_marker_enabled"):
+        _gm.set_graph_marker_enabled = lambda *a, **kw: None
+
+
+_stub_modelrunner_imports()
+
+
+# ---------------------------------------------------------------------------
+# Pool gating tests — the canonical #42 fix
+# ---------------------------------------------------------------------------
+
+
+class TestPoolGating:
+    def test_dummy_run_returns_none_none(self, monkeypatch):
+        """The canonical #42 fix: is_dummy_run short-circuits before pool admit."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        monkeypatch.setenv("ATOM_DSV4_USE_W4_PATH", "1")
+        # reload envs to pick up the new value
+        from atom.utils import envs as envs_mod
+
+        importlib.reload(envs_mod)
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = True
+        runner._dsv4_pool = MagicMock()  # if already inited
+
+        dummy_batch = MagicMock()
+        dummy_batch.is_dummy_run = True
+        dummy_batch.req_ids = [0, 1, 2, 3]
+
+        # Bind the real method to the mock
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            dummy_batch,
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+        # Critical: pool admit_request must NOT have been called
+        runner._dsv4_pool.admit_request.assert_not_called()
+
+    def test_flag_off_returns_none_none(self, monkeypatch):
+        """``ATOM_DSV4_USE_W4_PATH=0`` => also short-circuit."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        monkeypatch.setenv("ATOM_DSV4_USE_W4_PATH", "0")
+        from atom.utils import envs as envs_mod
+
+        importlib.reload(envs_mod)
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = True
+
+        real_batch = MagicMock()
+        real_batch.is_dummy_run = False
+        real_batch.req_ids = [0, 1]
+
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            real_batch,
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+
+    def test_non_dsv4_model_returns_none_none(self):
+        """Non-DSV4 models pass through untouched."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = False
+
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            batch=MagicMock(),
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+
+
+# ---------------------------------------------------------------------------
+# finish_request idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestFinishIdempotent:
+    def test_pool_finish_called_twice_is_safe(self):
+        """ModelRunner subscribes pool.finish_request to scheduler events.
+        finish_request must be idempotent under preempt-then-finish race.
+        """
+        import torch
+
+        from atom.engine.kv_pool.dsv4_pool import DSV4KVPool, DSV4KVPoolConfig
+
+        ratios = [4, 4, 128, 128]
+        cfg = DSV4KVPoolConfig(
+            max_active_seqs=4,
+            num_layers=4,
+            num_c4_layers=2,
+            num_c128_layers=2,
+            head_dim=32,
+            rope_head_dim=16,
+            window_size=32,
+            max_seq_len=128,
+            ring_size_main=32,
+            ring_size_compressor=8,
+            ring_size_indexer=32,
+            compress_ratio_per_layer=ratios,
+            state_inner_dim=32,
+            dtype=torch.float32,
+            state_dtype=torch.float32,
+            device=torch.device("cpu"),
+        )
+        pool = DSV4KVPool(cfg)
+        pool.admit_request(seq_id=0)
+        pool.finish_request(seq_id=0)
+        # Second call must not raise (idempotent)
+        pool.finish_request(seq_id=0)
+        # Third call also OK (never admitted; defensive no-op)
+        pool.finish_request(seq_id=999)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler subscription wiring (structural smoke check)
+# ---------------------------------------------------------------------------
+
+
+class TestNoDsv4ScheduleListener:
+    def test_modelrunner_subscribes_pool_to_scheduler(self):
+        """The wiring: ``ModelRunner._build_dsv4_pool`` source must reference
+        ``register_finish_listener`` (preferred) or at least the scheduler.
+
+        Smoke-style assertion since constructing a full ModelRunner+Scheduler
+        integration is too heavy for a unit test.
+        """
+        import inspect
+
+        from atom.model_engine.model_runner import ModelRunner
+
+        if hasattr(ModelRunner, "_build_dsv4_pool"):
+            src = inspect.getsource(ModelRunner._build_dsv4_pool)
+            assert "register_finish_listener" in src or "scheduler" in src.lower()
+        else:
+            pytest.skip("_build_dsv4_pool not yet implemented")

--- a/tests/test_scheduler_lifecycle_events.py
+++ b/tests/test_scheduler_lifecycle_events.py
@@ -1,0 +1,64 @@
+"""Scheduler emits seq lifecycle events via callback registry (issue #37 W4.3 P2.2).
+
+Establishes the ownership boundary: Scheduler does not know DSV4KVPool
+exists; ModelRunner subscribes pool.admit_request / pool.finish_request
+to these events.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestEventRegistry:
+    def test_admit_listener_registry_exists(self, scheduler):
+        """Public API: register_admit_listener(fn) appends fn to the registry."""
+        listener = MagicMock()
+        scheduler.register_admit_listener(listener)
+        assert listener in scheduler._admit_listeners
+
+    def test_finish_listener_registry_exists(self, scheduler):
+        listener = MagicMock()
+        scheduler.register_finish_listener(listener)
+        assert listener in scheduler._finish_listeners
+
+    def test_emit_admit_calls_all_admit_listeners(self, scheduler):
+        l1, l2 = MagicMock(), MagicMock()
+        scheduler.register_admit_listener(l1)
+        scheduler.register_admit_listener(l2)
+        scheduler._emit_admit(seq_id=42)
+        l1.assert_called_once_with(42)
+        l2.assert_called_once_with(42)
+
+    def test_emit_finish_calls_all_finish_listeners(self, scheduler):
+        l1, l2 = MagicMock(), MagicMock()
+        scheduler.register_finish_listener(l1)
+        scheduler.register_finish_listener(l2)
+        scheduler._emit_finish(seq_id=99)
+        l1.assert_called_once_with(99)
+        l2.assert_called_once_with(99)
+
+    def test_listener_exception_does_not_propagate(self, scheduler):
+        """A bad listener cannot break the scheduler."""
+        bad = MagicMock(side_effect=RuntimeError("oops"))
+        good = MagicMock()
+        scheduler.register_admit_listener(bad)
+        scheduler.register_admit_listener(good)
+        # Must not raise
+        scheduler._emit_admit(seq_id=1)
+        good.assert_called_once_with(1)
+
+
+class TestNoDsv4PoolImport:
+    def test_scheduler_source_does_not_reference_dsv4_pool(self):
+        """Ownership boundary check: scheduler.py must not import DSV4KVPool.
+
+        ModelRunner subscribes the pool's admit/finish methods to the
+        scheduler's events. The scheduler itself is pool-agnostic.
+        """
+        import atom.model_engine.scheduler as sched_mod
+
+        with open(sched_mod.__file__) as f:
+            src = f.read()
+        # The scheduler may have generic listener bookkeeping but must not
+        # know about DSV4KVPool specifically.
+        assert "DSV4KVPool" not in src
+        assert "dsv4_pool" not in src.lower()


### PR DESCRIPTION
## Summary

Task 9 of the DSV4 W4.3-Redo Sprint (issue #37). This is the **canonical fix** for the #42 root cause that crashed silicon.

- **ModelRunner becomes the sole owner of `DSV4KVPool`** per TP rank (P2.2). Pool is lazy-initialized on first real request; `pool.finish_request` is subscribed to the scheduler's finish-listener registry when a scheduler reference is reachable.
- **`is_dummy_run` short-circuit at the very entry of `_maybe_setup_dsv4_forward_batch`** - warmup synthetic tensors (MAX_BATCHED_TOKENS-sized) must NOT enter the W4 path; this is what crashed silicon with HSA exception 0x1016 in the original #42 PR.
- **Double gate**: also short-circuits when `ATOM_DSV4_USE_W4_PATH` is unset, so the W4 multi-request path can be opt-in even after this PR lands.
- `dsv4_pool` and `dsv4_forward_batch` are threaded through `ForwardContext` so models can read them via `get_forward_context()` without affecting the non-DSV4 forward path.

## Files Modified

| File | Lines |
|------|-------|
| `atom/model_engine/model_runner.py` | +168 |
| `atom/utils/forward_context.py` | +14 |
| `tests/test_modelrunner_dsv4_pool_lifecycle.py` | +287 (new) |

## Branch base

This branch sits on top of:
- PR #47 (Tasks 6+7: env vars + double opt-in guard) - merged in locally
- PR #48 (Task 8: scheduler lifecycle event registry) - merged in locally

If those PRs land on main first, this branch will rebase cleanly (the merge commits drop out).

## Test plan

- [x] `pytest tests/test_modelrunner_dsv4_pool_lifecycle.py` - 5 UT pass
  - `is_dummy_run=True` short-circuits before `pool.admit_request`
  - `ATOM_DSV4_USE_W4_PATH=0` short-circuits
  - non-DSV4 model passes through untouched
  - `pool.finish_request` is idempotent under preempt-then-finish race
  - `_build_dsv4_pool` source wires `register_finish_listener` (P2.2 boundary smoke check)
- [x] Cumulative DSV4 suite passes: 75 UT green (Task 6+7's 19 + Task 7's +3 + Task 8's +6 + Task 9's +5 + W4.1 19 + W4.2 23)
- [x] `ruff check atom/ tests/` - clean
- [x] `black --check` on touched files - clean
- [ ] Silicon validation deferred to W4.4+ (model still runs the legacy single-request fallback path; this PR only sets up the safe pool ownership boundary)

## Spec

`docs/superpowers/specs/2026-04-26-dsv4-w43-redo-aiter-track-design.md` SS3 (P2.2 ownership) + SS4 (warmup gate).

## Risk

- Low. The `_maybe_setup_dsv4_forward_batch` helper returns `(None, None)` for: non-DSV4 models, dummy warmup, flag-off. Only when all three conditions are positive does the pool initialize and admit seqs - and even then, model code does not yet consume `dsv4_forward_batch` (that's W4.4).
- Backward-compat: `set_forward_context` adds two new optional kwargs (default `None`); existing call sites are unaffected.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)