### PR TITLE
[W4.3-redo] DeepseekV4Attention W4 path (forward_batch + pool) (#37 Task 10)

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1748,6 +1748,164 @@ class ModelRunner:
         num_input_tokens = int(torch.max(num_tokens_across_dp).item())
         return num_input_tokens, num_tokens_across_dp, reqs_across_dp
 
+    # ------------------------------------------------------------------
+    # DSV4 W4 path helpers (issue sunway513/atom#37 P2.2 — W4.3-redo Task 9)
+    # ------------------------------------------------------------------
+
+    def _is_dsv4_model(self) -> bool:
+        """Detect DSV4 architectures from ``hf_config.architectures``.
+
+        Centralized so callers don't sprinkle string comparisons across
+        the codebase. Mirrors the multi-request guard used in
+        ``atom.utils.dsv4_guard``.
+        """
+        archs = getattr(self.config.hf_config, "architectures", None) or []
+        from atom.utils.dsv4_guard import is_dsv4_arch
+
+        return is_dsv4_arch(archs)
+
+    def _maybe_setup_dsv4_forward_batch(self, batch, attn_metadata, positions):
+        """W4.3-redo (issue #37): lazy-init pool, admit slots, build DSV4ForwardBatch.
+
+        Critical contract: ``is_dummy_run`` short-circuit at the VERY
+        entry. Warmup runs ``MAX_BATCHED_TOKENS``-sized synthetic tensors
+        that crash the W4 path with HSA exception 0x1016 (#37 Evidence
+        I / I' / I''). Only safe behavior is to fall through to the
+        legacy single-request path by returning ``(None, None)``.
+
+        Also short-circuits if ``ATOM_DSV4_USE_W4_PATH`` is unset — pool
+        allocation is harmless but admitting seqs without the flag would
+        leak slots and reorder kernels under the wrong feature gate.
+
+        Returns
+        -------
+        ``(pool, forward_batch)`` — both ``None`` if W4 path is not
+        active for this step, so callers can pass straight to
+        ``set_forward_context`` without further branching.
+        """
+        if not self._is_dsv4_model():
+            return None, None
+
+        # CRITICAL: must be first check after arch detection. This is the
+        # canonical fix for issue #42 — warmup synthetic tensors must NOT
+        # enter the W4 path.
+        if batch is not None and getattr(batch, "is_dummy_run", False):
+            return None, None
+
+        from atom.utils import envs
+
+        if not envs.ATOM_DSV4_USE_W4_PATH:
+            return None, None
+
+        if getattr(self, "_dsv4_pool", None) is None:
+            self._dsv4_pool = self._build_dsv4_pool()
+
+        # Admit any seqs in this batch the pool hasn't seen yet. Idempotent
+        # under re-admit (DSV4KVPool.admit_request returns the same slot).
+        seq_ids: list[int] = []
+        if batch is not None:
+            seq_ids = list(batch.req_ids)
+            for sid in seq_ids:
+                self._dsv4_pool.admit_request(sid)
+
+        forward_batch = None
+        if attn_metadata is not None and positions is not None:
+            try:
+                from atom.utils.dsv4_forward_batch import DSV4ForwardBatch
+
+                forward_batch = DSV4ForwardBatch.from_attn_metadata(
+                    attn_metadata,
+                    positions,
+                    seq_ids=seq_ids if seq_ids else None,
+                    pool=self._dsv4_pool,
+                )
+            except Exception as e:
+                logger.warning(
+                    "DSV4: failed to build ForwardBatch (%s); "
+                    "falling back to legacy path",
+                    e,
+                )
+                forward_batch = None
+
+        return self._dsv4_pool, forward_batch
+
+    def _build_dsv4_pool(self):
+        """Allocate a DSV4KVPool sized from the loaded model.
+
+        Reads layer count, head dim, window size, compress ratios, etc.
+        from the model's ``DeepseekV4Args`` dataclass. One pool per
+        ModelRunner = one per TP rank. If the runner has access to a
+        scheduler instance (``self.scheduler``), subscribes
+        ``pool.finish_request`` to the scheduler's finish-listener
+        registry — this is the P2.2 ownership boundary: the scheduler
+        stays pool-agnostic and the pool stays unaware of seq lifecycle
+        events except through the registered listener.
+        """
+        from atom.engine.kv_pool.dsv4_pool import DSV4KVPool, DSV4KVPoolConfig
+
+        args = self.model.args  # DeepseekV4Args
+
+        # Per-layer compress ratios. Prefer the canonical ``compress_ratios``
+        # tuple on DeepseekV4Args; fall back to an alternating 4/128 default
+        # for synthetic test models that don't populate it.
+        n_layers = args.n_layers
+        compress_ratios = getattr(args, "compress_ratios", ()) or ()
+        compress_ratio_per_layer: list[int] = []
+        for layer_idx in range(n_layers):
+            if layer_idx < len(compress_ratios):
+                r = int(compress_ratios[layer_idx])
+            else:
+                r = 128 if layer_idx % 2 == 0 else 4
+            compress_ratio_per_layer.append(r)
+        n_c4 = sum(1 for r in compress_ratio_per_layer if r == 4)
+        n_c128 = sum(1 for r in compress_ratio_per_layer if r == 128)
+
+        # Ring sizes mirror SGLang's get_compress_state_ring_size (4→8, 128→128).
+        ring_size_compressor = 2 * 4
+        ring_size_indexer = 2 * 64
+        ring_size_main = max(getattr(args, "window_size", 128), 64)
+
+        cfg = DSV4KVPoolConfig(
+            max_active_seqs=self.config.max_num_seqs,
+            num_layers=n_layers,
+            num_c4_layers=n_c4,
+            num_c128_layers=n_c128,
+            head_dim=args.head_dim,
+            rope_head_dim=getattr(args, "rope_head_dim", args.head_dim // 2),
+            window_size=getattr(args, "window_size", 128),
+            max_seq_len=getattr(args, "max_seq_len", 4096),
+            ring_size_main=ring_size_main,
+            ring_size_compressor=ring_size_compressor,
+            ring_size_indexer=ring_size_indexer,
+            compress_ratio_per_layer=compress_ratio_per_layer,
+            dtype=self.config.torch_dtype,
+            device=self.device,
+        )
+        pool = DSV4KVPool(cfg)
+
+        # P2.2 ownership boundary: subscribe pool's finish_request to the
+        # scheduler's finish events when one is reachable from the runner.
+        # In ATOM today the scheduler lives in EngineCore (parent process)
+        # while ModelRunner runs in a child process, so this branch is a
+        # no-op in production; it exists for in-process integration tests
+        # that hand a scheduler reference to the runner. The wiring shape
+        # is the canonical one — Scheduler stays pool-agnostic.
+        scheduler = getattr(self, "scheduler", None)
+        if scheduler is not None and hasattr(scheduler, "register_finish_listener"):
+            scheduler.register_finish_listener(pool.finish_request)
+
+        logger.info(
+            "DSV4 KV pool: n_layers=%d c4=%d c128=%d max_active_seqs=%d "
+            "window=%d device=%s",
+            n_layers,
+            n_c4,
+            n_c128,
+            cfg.max_active_seqs,
+            cfg.window_size,
+            cfg.device,
+        )
+        return pool
+
     def prepare_inputs(self, batch: ScheduledBatch, input_ids: torch.Tensor = None):
         is_prefill = batch.total_tokens_num_prefill > 0
         bs = batch.total_seqs_num
@@ -1812,6 +1970,14 @@ class ModelRunner:
             reqs_across_dp,
         )
 
+        # W4.3-redo (issue #37 P2.2): set up DSV4 W4-path pool + ForwardBatch
+        # if and only if (a) model is DSV4, (b) batch is not a dummy warmup,
+        # and (c) ATOM_DSV4_USE_W4_PATH is enabled. Returns (None, None)
+        # otherwise so the legacy single-request fallback path runs.
+        dsv4_pool, dsv4_forward_batch = self._maybe_setup_dsv4_forward_batch(
+            batch, attn_metadata, positions
+        )
+
         set_forward_context(
             attn_metadata=attn_metadata,
             atom_config=self.config,
@@ -1820,6 +1986,8 @@ class ModelRunner:
             num_tokens_across_dp=num_tokens_across_dp,
             spec_decode_metadata=spec_decode_metadata,
             ubatch_slices=ubatch_slices,
+            dsv4_pool=dsv4_pool,
+            dsv4_forward_batch=dsv4_forward_batch,
         )
         return graph_bs
 

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -397,6 +397,40 @@ class Scheduler:
 
         self.kv_connector = get_kvconnector("scheduler", config)
 
+        # W4.3 (issue #37 P2.2): seq lifecycle event registry. ModelRunner
+        # subscribes its KV pool admit/finish methods here. Scheduler is
+        # pool-agnostic — it must not import or reference any concrete pool.
+        self._admit_listeners: list = []
+        self._finish_listeners: list = []
+
+    def register_admit_listener(self, fn) -> None:
+        """Subscribe a callable(seq_id: int) -> None to be invoked on admit.
+
+        Used by ModelRunner to wire pool admit_request without leaking
+        pool dependencies into the scheduler.
+        """
+        self._admit_listeners.append(fn)
+
+    def register_finish_listener(self, fn) -> None:
+        """Subscribe a callable(seq_id: int) -> None to be invoked on finish/preempt."""
+        self._finish_listeners.append(fn)
+
+    def _emit_admit(self, seq_id: int) -> None:
+        for listener in self._admit_listeners:
+            try:
+                listener(seq_id)
+            except Exception as e:
+                logger.warning("Seq admit listener %s raised %s; ignoring", listener, e)
+
+    def _emit_finish(self, seq_id: int) -> None:
+        for listener in self._finish_listeners:
+            try:
+                listener(seq_id)
+            except Exception as e:
+                logger.warning(
+                    "Seq finish listener %s raised %s; ignoring", listener, e
+                )
+
     def is_finished(self):
         return not self.waiting and not self.running
 
@@ -467,6 +501,7 @@ class Scheduler:
                 seq.status = SequenceStatus.RUNNING
                 seq.is_first_decode = True
                 self.running.append(seq)
+                self._emit_admit(seq.id)
                 continue
 
             num_seqs_prefill += 1
@@ -479,6 +514,7 @@ class Scheduler:
             self.running.append(seq)
             scheduled_seqs[seq.id] = seq
             num_scheduled_tokens.append(num_new_tokens)
+            self._emit_admit(seq.id)
 
         if skipped_waiting_requests:
             logger.debug(
@@ -577,6 +613,8 @@ class Scheduler:
         seq.spec_token_ids = np.array([], dtype=np.int32)
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
+        # Notify lifecycle subscribers: seq is no longer running.
+        self._emit_finish(seq.id)
 
     def postprocess(
         self,
@@ -729,6 +767,8 @@ class Scheduler:
             else:
                 self.block_manager.deallocate(seq)
             self.running.remove(seq)
+            # Notify lifecycle subscribers: seq has finished.
+            self._emit_finish(seq.id)
         return finished_seqs
 
     def _update_waiting_for_remote_kv(self, seq: Sequence) -> bool:

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -399,6 +399,84 @@ def _get_window_topk_idxs(
     return matrix.unsqueeze(0).expand(bsz, -1, -1)
 
 
+def _get_window_topk_idxs_pertoken(
+    window_size: int,
+    positions: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    device: Optional[torch.device] = None,
+) -> torch.Tensor:
+    """Per-token sliding-window topk indices for multi-seq packed batches.
+
+    W4.3-redo (issue sunway513/atom#37): the cached
+    ``_get_window_topk_idxs`` helper above assumes a single ``start_pos``
+    scalar per call — fine for the legacy B=1-implicit single-sequence
+    path, but fundamentally wrong when N different sequences have N
+    different per-seq positions in the same packed batch. This per-token
+    variant builds one row per token using the token's actual absolute
+    ``positions[t]`` value, eliminating the cross-talk that the W3.2
+    v3..v6.1 archive chain repeatedly tried to patch around.
+
+    Args
+    ----
+    window_size: ring size of the sliding-window KV cache.
+    positions: ``[num_tokens]`` long, absolute token positions
+        (``DSV4ForwardBatch.positions``).
+    cu_seqlens_q: ``[num_seqs+1]`` long, cumulative-tokens-per-seq
+        prefix sum. Used to derive each token's in-seq offset so prefill
+        rows still span only the seq's own keys.
+    device: target device for the returned tensor.
+
+    Returns
+    -------
+    ``[num_tokens, window_size]`` int64 tensor where ``-1`` marks a
+    masked (causal-future) slot. Caller is expected to ``unsqueeze(0)``
+    for the legacy 3D ``[1, T, K]`` shape.
+
+    Semantics
+    ---------
+    - Decode token (one new token per seq, position p):
+      ``out[t] = [(p+1) % W, (p+2) % W, ..., (p+W) % W]``  modulo window
+      — the row matches what the legacy helper produced for that single
+      seq.
+    - Prefill token within a seq (positions 0..S-1): mirrors the legacy
+      helper's ``else`` branch (causal mask) — each query at offset i
+      sees only positions ``[max(0, i-W+1) .. i]``.
+
+    Both branches are unified by computing each row from its absolute
+    ``positions[t]`` and the per-seq starting position, regardless of
+    whether the seq is in prefill or decode.
+    """
+    if device is None:
+        device = positions.device
+    T = positions.numel()
+    W = window_size
+    if T == 0:
+        return torch.zeros(0, W, dtype=torch.long, device=device)
+
+    cu_long = cu_seqlens_q.to(device=device, dtype=torch.long)
+    # token_idx → seq_idx via right-bucketize on cu[1:].
+    token_idx = torch.arange(T, dtype=torch.long, device=device)
+    seg_id = torch.bucketize(token_idx, cu_long[1:], right=True)
+    seq_starts = cu_long[seg_id]  # first token-idx of this token's seq
+    in_seq_offset = token_idx - seq_starts  # 0-based within the seq
+
+    pos = positions.to(device=device, dtype=torch.long)
+    # Per-token row template:
+    #   out[t, k] = (start_p + k) % W,  start_p = pos[t] - in_seq_offset[t]
+    # plus a causal mask on the early prefill rows.
+    arange_w = torch.arange(W, dtype=torch.long, device=device)
+
+    # Rotated window for "fully-warm" tokens (pos >= W-1): unrolled with
+    # the modular arithmetic used by `_get_window_topk_idxs`'s warm
+    # branch, this is identical. Early-prefill (pos < W-1) → invalid
+    # future slots = -1.
+    base = pos.unsqueeze(1) - in_seq_offset.unsqueeze(1) + arange_w.unsqueeze(0)
+    ring_idx = base % W
+    valid = (base >= 0) & (base <= pos.unsqueeze(1))
+    out = torch.where(valid, ring_idx, torch.full_like(ring_idx, -1))
+    return out
+
+
 @lru_cache(2)
 def _get_compress_topk_idxs(
     ratio: int,
@@ -985,6 +1063,12 @@ class DeepseekV4Attention(nn.Module):
             self.indexer = None
 
         # ----- KV cache: [B, window_size + max_seq_len/ratio, head_dim] -----
+        # Legacy single-request kv_cache. The W4 path
+        # (forward_batch != None && ATOM_DSV4_USE_W4_PATH=1) consumes a
+        # per-layer view of the engine-owned ``DSV4KVPool`` instead. This
+        # buffer is preserved verbatim so the bit-for-bit legacy fallback
+        # path (warmup, single-seq eager, PR1 toy validation) still works
+        # exactly as it did post-#44 main.
         kv_cache_size = args.window_size + (
             args.max_seq_len // self.compress_ratio if self.compress_ratio else 0
         )
@@ -1091,16 +1175,55 @@ class DeepseekV4Attention(nn.Module):
 
         self.wo_a.quant_type = _QT.No
 
-    def forward(self, x: torch.Tensor, start_pos: int) -> torch.Tensor:
-        """Compute attention for `x` at absolute position `start_pos`.
+    def forward(
+        self,
+        x: torch.Tensor,
+        start_pos: int = 0,
+        forward_batch: Optional[Any] = None,
+    ) -> torch.Tensor:
+        """W4.3-redo (issue sunway513/atom#37): dispatch on flag + forward_batch.
+
+        Two operating modes:
+
+        - **Legacy single-request path** (``_forward_legacy``):
+          ``forward_batch is None`` OR ``ATOM_DSV4_USE_W4_PATH=0``. The
+          pre-W4.3-redo body is preserved bit-for-bit so warmup,
+          single-seq eager, and PR1 toy validation behave exactly as
+          they did post-#44 main.
+
+        - **W4 multi-request path** (``_forward_w4``): both
+          ``forward_batch is not None`` AND ``ATOM_DSV4_USE_W4_PATH=1``.
+          Per-token RoPE, per-seq slot KV scatter via the engine
+          ``DSV4KVPool``, validator gate before ``sparse_attn``.
 
         Args:
-            x: [num_tokens, dim] flat ATOM convention. Single-sequence
+            x: ``[num_tokens, dim]`` flat ATOM convention.
+            start_pos: legacy scalar position (only used in legacy path).
+            forward_batch: optional ``DSV4ForwardBatch`` carrying per-step
+                multi-request metadata.
+        Returns:
+            ``[num_tokens, dim]`` attention output (BF16).
+        """
+        from atom.utils import envs
+
+        if forward_batch is None or not envs.ATOM_DSV4_USE_W4_PATH:
+            return self._forward_legacy(x, start_pos)
+        return self._forward_w4(x, forward_batch)
+
+    def _forward_legacy(self, x: torch.Tensor, start_pos: int = 0) -> torch.Tensor:
+        """Legacy single-request path. Bit-for-bit preserved post-#44.
+
+        This is the entire pre-W4.3-redo ``forward()`` body, copied
+        verbatim. Do not optimize, refactor, or "improve" — bit-for-bit
+        preservation under flag-off is the contract.
+
+        Args:
+            x: ``[num_tokens, dim]`` flat ATOM convention. Single-sequence
                 (B=1 implicit; multi-sequence batching needs attn_metadata,
-                deferred until ATOM's scheduler integration).
+                handled by ``_forward_w4`` instead).
             start_pos: absolute position of the first token in this batch.
         Returns:
-            [num_tokens, dim] attention output (BF16).
+            ``[num_tokens, dim]`` attention output (BF16).
         """
         assert (
             x.dim() == 2
@@ -1237,6 +1360,168 @@ class DeepseekV4Attention(nn.Module):
 
         # ----- Grouped output LoRA -----
         # o: [1, S, H, D] → drop B; reshape into groups for the einsum.
+        o = o.squeeze(0).view(seqlen, self.n_local_groups, -1)  # [S, g, H/g * D]
+        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+        o = torch.einsum("sgd,grd->sgr", o, wo_a)  # [S, g, o_lora_rank]
+        x = self.wo_b(o.flatten(1))  # 2D [S, dim]
+        return x
+
+    def _build_topk_per_token(self, forward_batch: Any) -> torch.Tensor:
+        """Build per-token sliding-window topk_idxs for the W4 path.
+
+        Adapts the W3.2-v6 archive's per-token math to the
+        ``DSV4ForwardBatch`` shape (``positions`` + ``cu_seqlens_q``).
+
+        Returns
+        -------
+        ``[1, num_tokens, window_size]`` int64 tensor (the leading ``B=1``
+        dim matches the legacy ``[1, N, K]`` shape downstream code
+        expects). Sentinels: ``-1`` marks causal-future / invalid slots.
+        """
+        return _get_window_topk_idxs_pertoken(
+            self.window_size,
+            forward_batch.positions,
+            forward_batch.cu_seqlens_q,
+            device=forward_batch.positions.device,
+        ).unsqueeze(0)
+
+    def _forward_w4(
+        self,
+        x: torch.Tensor,
+        forward_batch: Any,
+    ) -> torch.Tensor:
+        """W4 multi-request path (issue sunway513/atom#37).
+
+        Per-token RoPE via ``self.freqs_cis[positions]``, per-seq slot
+        KV scatter via ``DSV4KVPool.compute_out_cache_loc``, validator
+        gate (``ATOM_AITER_VALIDATE``) before ``sparse_attn``. Each
+        token's query attends to its OWN seq's slot row in the pool,
+        eliminating the row-0 collision class of bugs documented in
+        W3.2 v3..v6.1.
+
+        Compressor / Indexer state remains ``register_buffer``-owned in
+        Task 10 (lifted to the pool by Tasks 11/12). The W4 path here
+        skips compressor/indexer activations and uses window-only
+        topk_idxs. Compressed-attention multi-request prefill is
+        explicitly out of scope until Tasks 11/12.
+
+        Args:
+            x: ``[num_tokens, dim]`` flat ATOM convention.
+            forward_batch: ``DSV4ForwardBatch`` (must carry a non-None
+                ``kv_pool``).
+        Returns:
+            ``[num_tokens, dim]`` attention output (BF16).
+        """
+        from atom.utils import envs
+
+        assert (
+            x.dim() == 2
+        ), f"DeepseekV4Attention expects 2D [num_tokens, dim], got {x.shape}"
+        assert (
+            forward_batch.kv_pool is not None
+        ), "_forward_w4 requires a non-None forward_batch.kv_pool"
+
+        positions = forward_batch.positions  # [num_tokens] long
+        rd = self.rope_head_dim
+
+        # Per-layer pool view: [num_active_seqs, ring_main, head_dim].
+        # Zero-copy slice; rebound every step.
+        pool_view = forward_batch.kv_pool.view_for_layer(self.layer_id)
+        kv_cache_view = pool_view["kv_cache"]
+        n_slots, ring_main, head_dim = kv_cache_view.shape
+
+        # ---- Per-token RoPE (CRITICAL — was the W3.2-v5 wall) ----
+        # Gather one row per token by absolute position. Under
+        # multi-request decode, the N tokens in a packed batch belong to
+        # N distinct seqs at N distinct positions; the legacy
+        # `freqs_cis[start_pos:start_pos+seqlen]` contiguous slice
+        # silently gave every seq the same frequency.
+        freqs_cis = self.freqs_cis[positions]
+
+        # ---- Q: low-rank projection + per-head RMSNorm + partial RoPE ----
+        seqlen = x.size(0)
+        qr = self.q_norm(self.wq_a(x))  # [seqlen, q_lora_rank]
+        q = self.wq_b(qr).view(seqlen, self.n_local_heads, self.head_dim)
+        q = q * torch.rsqrt(q.square().mean(-1, keepdim=True) + self.eps)
+        q = q.unsqueeze(0)  # [1, seqlen, H, D]
+        _apply_rotary_emb(q[..., -rd:], freqs_cis)
+
+        # ---- KV: project, RMSNorm, RoPE on rope dims, FP8-sim on nope ----
+        kv = self.wkv(x)  # [seqlen, head_dim]
+        kv = self.kv_norm(kv).unsqueeze(0)  # [1, seqlen, head_dim]
+        _apply_rotary_emb(kv[..., -rd:], freqs_cis)
+        act_quant_inplace(kv[..., :-rd], 64, self.scale_fmt)
+
+        # ---- Per-token slot scatter into the pool's main ring ----
+        if forward_batch.out_cache_loc is not None:
+            out_cache_loc = forward_batch.out_cache_loc.to(
+                device=x.device, dtype=torch.long
+            )
+        else:
+            out_cache_loc = forward_batch.kv_pool.compute_out_cache_loc(
+                positions=positions,
+                slot_indices=forward_batch.req_pool_indices,
+                cu_seqlens_q=forward_batch.cu_seqlens_q,
+                ring="main",
+            )
+        kv_tok = kv.squeeze(0)  # [num_tokens, head_dim]
+        # Flatten the [N, ring_main, D] pool view to [N*ring_main, D] for
+        # scatter. Zero-copy reshape — pool storage is contiguous.
+        kv_flat = kv_cache_view.view(n_slots * ring_main, head_dim)
+        # Cast scatter source to pool dtype to avoid silent zero-out from
+        # an implicit dtype-mismatch copy_.
+        kv_flat[out_cache_loc] = kv_tok.to(kv_flat.dtype)
+
+        # ---- Per-token window topk_idxs ----
+        topk_idxs = self._build_topk_per_token(forward_batch)  # [1, T, win] int64
+        topk_idxs = topk_idxs.int()
+
+        # ---- Build per-token KV slabs: each token attends to its OWN
+        # seq's pool row. ----
+        num_tokens = kv_tok.shape[0]
+        token_idx = torch.arange(num_tokens, dtype=torch.long, device=x.device)
+        cu_long = forward_batch.cu_seqlens_q.to(device=x.device, dtype=torch.long)
+        seg_id = torch.bucketize(token_idx, cu_long[1:], right=True)
+        slot_per_token = forward_batch.req_pool_indices.to(
+            device=x.device, dtype=torch.long
+        )[seg_id]
+        kv_per_token = kv_cache_view[slot_per_token]  # [T, ring_main, D]
+        q_per_token = q.transpose(0, 1).contiguous()  # [T, 1, H, D]
+        topk_per_token = topk_idxs.transpose(0, 1).contiguous()  # [T, 1, K]
+
+        # ---- Validator gate: catch shape/dtype/OOB BEFORE the GPU kernel ----
+        if envs.ATOM_AITER_VALIDATE:
+            try:
+                from aiter.dsv4_validate import dsv4_validate_sparse_attn_metadata
+
+                dsv4_validate_sparse_attn_metadata(
+                    q=q_per_token,
+                    kv=kv_per_token,
+                    topk_idxs=topk_per_token,
+                    slot_mapping=out_cache_loc,
+                    positions=positions,
+                    cu_seqlens_q=forward_batch.cu_seqlens_q,
+                    pool_capacity=n_slots,
+                )
+            except ImportError:
+                # Validator not available in this aiter build — proceed
+                # without it. ATOM_AITER_VALIDATE is opt-in for debug.
+                pass
+
+        # ---- sparse_attn (W4 per-token call: B=num_tokens, M=1) ----
+        o = sparse_attn(
+            q_per_token,
+            kv_per_token,
+            self.attn_sink,
+            topk_per_token,
+            self.softmax_scale,
+        )
+        o = o.transpose(0, 1).contiguous()  # back to [1, T, H, D]
+
+        # Inverse RoPE on output's rope dims (legacy semantics).
+        _apply_rotary_emb(o[..., -rd:], freqs_cis, inverse=True)
+
+        # ----- Grouped output LoRA -----
         o = o.squeeze(0).view(seqlen, self.n_local_groups, -1)  # [S, g, H/g * D]
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
         o = torch.einsum("sgd,grd->sgr", o, wo_a)  # [S, g, o_lora_rank]
@@ -1768,6 +2053,7 @@ class Block(nn.Module):
         x: torch.Tensor,
         start_pos: int,
         input_ids: Optional[torch.Tensor],
+        forward_batch: Optional[Any] = None,
     ) -> torch.Tensor:
         # ----- Attention sub-layer with mHC mixing -----
         residual = x
@@ -1775,7 +2061,11 @@ class Block(nn.Module):
             x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
         )
         x = self.attn_norm(x)
-        x = self.attn(x, start_pos)
+        # W4.3-redo (issue sunway513/atom#37): pass the per-step
+        # DSV4ForwardBatch through to Attention. The legacy single-
+        # request path (forward_batch is None or flag off) keeps the
+        # scalar `start_pos` semantics inside `_forward_legacy`.
+        x = self.attn(x, start_pos, forward_batch=forward_batch)
         x = self.hc_post(x, residual, post, comb)
 
         # ----- FFN sub-layer with mHC mixing -----
@@ -1914,7 +2204,11 @@ class MTPBlock(Block):
         self.head: Optional[ParallelHead] = None
 
     def forward(
-        self, x: torch.Tensor, start_pos: int, input_ids: torch.Tensor
+        self,
+        x: torch.Tensor,
+        start_pos: int,
+        input_ids: torch.Tensor,
+        forward_batch: Optional[Any] = None,
     ) -> torch.Tensor:
         """Forward.
 
@@ -1923,6 +2217,9 @@ class MTPBlock(Block):
                 (ATOM 2D-flat convention) or [B, S, hc, D] (legacy 4D).
             start_pos: absolute position offset.
             input_ids: matching token ids.
+            forward_batch: optional ``DSV4ForwardBatch`` (W4.3-redo
+                issue sunway513/atom#37). Threaded through to the
+                inherited Block.forward → Attention.
         Returns:
             Logits of the last token (vocab projected by self.head).
         """
@@ -1936,7 +2233,7 @@ class MTPBlock(Block):
         # adds the hc dim before the trailing D so [num_tokens, D] → [num_tokens, 1, D]
         # broadcasts correctly against x [num_tokens, hc, D]. Same for 4D path.
         x = self.e_proj(e).unsqueeze(-2) + self.h_proj(x)
-        x = super().forward(x, start_pos, input_ids)
+        x = super().forward(x, start_pos, input_ids, forward_batch=forward_batch)
         logits = self.head(
             x, self.hc_head_fn, self.hc_head_scale, self.hc_head_base, self.norm
         )
@@ -1999,6 +2296,7 @@ class DeepseekV4Model(nn.Module):
         self,
         input_ids: torch.Tensor,
         start_pos: int = 0,
+        forward_batch: Optional[Any] = None,
         **model_kwargs: dict,
     ) -> torch.Tensor:
         """Forward.
@@ -2007,22 +2305,32 @@ class DeepseekV4Model(nn.Module):
             input_ids: 1D `[num_tokens]` (ATOM 2D-flat convention) OR 2D
                 `[B, S]` (legacy reference convention; treated as a single
                 sequence of B*S tokens — only correct for B=1).
-            start_pos: absolute position of the first token.
+            start_pos: absolute position of the first token (legacy
+                single-request fallback). Ignored on the W4 path.
+            forward_batch: optional ``DSV4ForwardBatch`` (W4.3-redo
+                issue sunway513/atom#37). When non-None, threaded into
+                each ``Block.forward`` so ``DeepseekV4Attention`` can
+                dispatch into ``_forward_w4`` (per-token RoPE, per-seq
+                slot scatter).
         Returns:
-            Logits of the last token: `[vocab]` (1D path) or `[B, vocab]` (2D path).
+            Logits per sample row: ``[N_sample, vocab]`` for batched
+            requests (one row per active seq) or ``[vocab]``-style legacy
+            output for the single-request path.
         """
         # Normalize input_ids to 1D [num_tokens] for the 2D internal convention.
         if input_ids.dim() == 2:
-            assert (
-                input_ids.size(0) == 1
-            ), "B>1 batched input_ids needs attn_metadata; not supported yet"
+            if forward_batch is None:
+                # Legacy assert: only B=1 supported in the start_pos path.
+                assert (
+                    input_ids.size(0) == 1
+                ), "B>1 batched input_ids needs forward_batch (W4 path)"
             input_ids = input_ids.flatten()
         h = self.embed(input_ids)  # [num_tokens, dim]
         # Expand to hc_mult copies for Hyper-Connections: [num_tokens, hc, dim]
         h = h.unsqueeze(-2).repeat(1, self.hc_mult, 1)
 
         for layer in self.layers:
-            h = layer(h, start_pos, input_ids)
+            h = layer(h, start_pos, input_ids, forward_batch=forward_batch)
 
         # W3.2 (RFC §14 Week 3): slice h to last-token-of-each-sequence
         # using cu_seqlens_q from attn_metadata before the LM head, so a
@@ -2031,17 +2339,21 @@ class DeepseekV4Model(nn.Module):
         # only the trailing row, giving 1 sample for any N — exactly the
         # IndexError@scheduler.py:609 RFC §3.1 #7 evidence chain captured
         # in W3.2-DEBUG (len(prev_token_ids)=1, len(req_ids)=4).
-        try:
-            from atom.utils.forward_context import get_forward_context
+        cu = None
+        if forward_batch is not None:
+            cu = forward_batch.cu_seqlens_q
+        else:
+            try:
+                from atom.utils.forward_context import get_forward_context
 
-            ctx = get_forward_context()
-            attn_meta = getattr(ctx, "attn_metadata", None)
-            cu = getattr(attn_meta, "cu_seqlens_q", None)
-        except Exception:
-            cu = None
+                ctx = get_forward_context()
+                attn_meta = getattr(ctx, "attn_metadata", None)
+                cu = getattr(attn_meta, "cu_seqlens_q", None)
+            except Exception:
+                cu = None
         if cu is not None and cu.numel() >= 2:
             last_token_indices = cu[1:] - 1
-            h = h[last_token_indices]
+            h = h[last_token_indices.to(h.device)]
 
         logits = self.head(
             h, self.hc_head_fn, self.hc_head_scale, self.hc_head_base, self.norm
@@ -2120,8 +2432,40 @@ class DeepseekV4ForCausalLM(nn.Module):
         inputs_embeds: Optional[torch.Tensor] = None,
         **model_kwargs: dict,
     ) -> torch.Tensor:
+        """W4.3-redo (issue sunway513/atom#37): wire DSV4ForwardBatch into
+        the model.
+
+        Three resolution paths:
+
+        1. Caller passes ``forward_batch=...`` in ``model_kwargs``
+           (used by unit tests).
+        2. ``ForwardContext.dsv4_forward_batch`` is populated by
+           ``ModelRunner._maybe_setup_dsv4_forward_batch`` (Task 9).
+           Promote to the W4 path.
+        3. Otherwise: fall back to the legacy ``start_pos`` scalar path
+           (warmup, single-seq eager, PR1 toy validation).
+        """
+        # Path 1: explicit kwarg from a test caller.
+        forward_batch = model_kwargs.pop("forward_batch", None)
+
+        # Path 2: pull from the engine's ForwardContext.
+        if forward_batch is None:
+            try:
+                from atom.utils.forward_context import get_forward_context
+
+                ctx = get_forward_context()
+                forward_batch = getattr(ctx, "dsv4_forward_batch", None)
+            except Exception:
+                forward_batch = None
+
+        # Path 3: legacy scalar start_pos.
         start_pos = int(positions[0].item()) if positions is not None else 0
-        return self.model(input_ids=input_ids, start_pos=start_pos, **model_kwargs)
+        return self.model(
+            input_ids=input_ids,
+            start_pos=start_pos,
+            forward_batch=forward_batch,
+            **model_kwargs,
+        )
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # In V4, the LM head is fused into DeepseekV4Model.forward (it consumes

--- a/atom/utils/dsv4_guard.py
+++ b/atom/utils/dsv4_guard.py
@@ -35,12 +35,16 @@ def validate_dsv4_multireq(architectures: list[str], max_num_seqs: int) -> None:
     engine-owned KV pools, branch `feat/dsv4-forward-batch-paged-kv`).
 
     Until W4 lands, refuse multi-request configs to prevent silently-
-    broken output. The `ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1` env override
-    exists for kernel-level perf experiments where output correctness
-    is not being measured.
+    broken output. Bypass requires **double opt-in** (W4.3 amendment,
+    PR #46 P1.1 review fix): BOTH `ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1`
+    AND `ATOM_DSV4_USE_W4_PATH=1` must be set together. Either alone
+    rejects, because `UNSAFE_MULTIREQ_DEV=1` without the W4 path opt-in
+    would route through the legacy (broken) multi-request path that
+    crashed PR #42 with HSA exception 0x1016.
 
     Raises:
-        ValueError: when DSV4 + max_num_seqs > 1 + override unset.
+        ValueError: when DSV4 + max_num_seqs > 1 + double opt-in
+            unsatisfied (either flag missing).
     """
     if not is_dsv4_arch(architectures):
         return
@@ -48,15 +52,24 @@ def validate_dsv4_multireq(architectures: list[str], max_num_seqs: int) -> None:
         return
     from atom.utils import envs
 
-    if envs.ATOM_DSV4_UNSAFE_MULTIREQ_DEV:
-        return
-    raise ValueError(
-        "DSV4 architectures currently support only "
-        f"max_num_seqs=1 (got max_num_seqs={max_num_seqs}). "
-        "Multi-request support is in development on the W4 branch "
-        "(feat/dsv4-forward-batch-paged-kv); see "
-        "https://github.com/sunway513/ATOM/issues/37 for context. "
-        "To bypass this guard for kernel-level perf experiments "
-        "where output correctness is NOT being measured, set "
-        "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1."
-    )
+    unsafe = envs.ATOM_DSV4_UNSAFE_MULTIREQ_DEV
+    use_w4 = envs.ATOM_DSV4_USE_W4_PATH
+
+    if not unsafe:
+        raise ValueError(
+            "DSV4 architectures currently support only "
+            f"max_num_seqs=1 (got max_num_seqs={max_num_seqs}). "
+            "Multi-request support is in development on the W4 branch; "
+            "see https://github.com/sunway513/ATOM/issues/37. To bypass "
+            "this guard for kernel-level perf experiments where output "
+            "correctness is NOT being measured, set BOTH "
+            "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1 AND ATOM_DSV4_USE_W4_PATH=1."
+        )
+    if not use_w4:
+        raise ValueError(
+            "DSV4 multi-request requires ATOM_DSV4_USE_W4_PATH=1 to opt "
+            "into the W4 path. ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1 alone "
+            "would route through the legacy (broken) multi-request "
+            "path. See issue #37."
+        )
+    # Both flags set → allow

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -105,6 +105,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": lambda: (
         os.getenv("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", "0") == "1"
     ),
+    # --- DSV4 W4.3-redo flags (issue #37) ---
+    # Enable the W4 multi-request path. When 0 (default), DSV4 single-request
+    # legacy path runs unchanged. Task 7 amends the Path 2 guard to require
+    # this flag together with ATOM_DSV4_UNSAFE_MULTIREQ_DEV before allowing
+    # max_num_seqs > 1.
+    "ATOM_DSV4_USE_W4_PATH": lambda: (os.getenv("ATOM_DSV4_USE_W4_PATH", "0") == "1"),
+    # Enable host-side AITER ABI validator before each sparse_attn call.
+    # Zero prod overhead when off.
+    "ATOM_AITER_VALIDATE": lambda: (os.getenv("ATOM_AITER_VALIDATE", "0") == "1"),
 }
 
 

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -329,6 +329,16 @@ class ForwardContext:
 
     ubatch_slices: Optional[list[Any]] = None
 
+    # W4.3-redo (issue #37 P2.2): the per-step DSV4 KV pool + ForwardBatch.
+    # Both fields stay ``None`` for non-DSV4 models, for DSV4 in legacy single-
+    # request fallback, and for the warmup ``is_dummy_run`` path. Models read
+    # ``dsv4_forward_batch`` to dispatch into the W4 multi-request kernel chain
+    # and ``dsv4_pool`` if they need direct slot lookups (typed as ``Any`` to
+    # avoid a circular import on ``DSV4KVPool`` / ``DSV4ForwardBatch``).
+    dsv4_pool: Optional[Any] = None
+
+    dsv4_forward_batch: Optional[Any] = None
+
     def __post_init__(self):
         if not hasattr(self, "no_compile_layers") or self.no_compile_layers is None:
             self.no_compile_layers = {}
@@ -366,6 +376,8 @@ def set_forward_context(
     num_tokens_across_dp: Optional[torch.Tensor] = None,
     spec_decode_metadata: Optional[SpecDecodeMetadata] = None,
     ubatch_slices: Optional[list[Any]] = None,
+    dsv4_pool: Optional[Any] = None,
+    dsv4_forward_batch: Optional[Any] = None,
 ) -> None:
     global _forward_context
     dp_metadata: Optional[DPMetadata] = None
@@ -385,6 +397,8 @@ def set_forward_context(
         dp_metadata=dp_metadata,
         spec_decode_metadata=spec_decode_metadata,
         ubatch_slices=ubatch_slices,
+        dsv4_pool=dsv4_pool,
+        dsv4_forward_batch=dsv4_forward_batch,
     )  # _forward_context.attn_metadata = attn_metadata
     # _forward_context.no_compile_layers = atom_config.compilation_config.static_forward_context
     # _forward_context = ForwardContext(no_compile_layers=atom_config.compilation_config.static_forward_context, attn_metadata=attn_metadata)

--- a/tests/test_deepseek_v4_w43_redo.py
+++ b/tests/test_deepseek_v4_w43_redo.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""W4.3-redo: DeepseekV4Attention consumes DSV4ForwardBatch + KVPool (issue sunway513/atom#37).
+
+Validates spec §3 'ATOM W4.3-redo (main attention)' component:
+
+- ``DeepseekV4Attention.forward`` accepts an optional ``forward_batch``
+  kwarg.
+- ``ATOM_DSV4_USE_W4_PATH=1`` + non-None ``forward_batch`` enters the
+  per-token RoPE / per-seq slot KV scatter path (``_forward_w4``).
+- ``ATOM_DSV4_USE_W4_PATH=0`` (or ``forward_batch is None``) keeps the
+  legacy single-request register_buffer path (``_forward_legacy``,
+  bit-for-bit preserved post-#44).
+- ``_forward_w4`` calls the AITER metadata validator
+  (``dsv4_validate_sparse_attn_metadata``) immediately before
+  ``sparse_attn`` when ``ATOM_AITER_VALIDATE=1``.
+- ``_forward_w4`` uses per-token RoPE indexing
+  (``freqs_cis[positions]``) rather than the legacy
+  ``freqs_cis[start_pos:start_pos+seqlen]`` contiguous slice (the
+  W3.2 v3..v6.1 bug class).
+- ``register_buffer("kv_cache", ...)`` is preserved in ``__init__`` for
+  the legacy fallback (deliberate, per Task 10 spec §10.6).
+
+We use AST-level inspection so the test runs on CPU without HF
+download or GPU. ``DeepseekV4ForCausalLM`` instantiation pulls in
+aiter ROCm kernels that the unit-test image's stubbed ``aiter``
+cannot satisfy. The full forward smoke run is silicon-validation
+territory (Task 14).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# AST helpers — read the source without importing the module
+# ---------------------------------------------------------------------------
+
+ATOM_ROOT = Path(__file__).resolve().parent.parent
+DSV4_SOURCE = ATOM_ROOT / "atom" / "models" / "deepseek_v4.py"
+
+
+def _tree() -> ast.Module:
+    return ast.parse(DSV4_SOURCE.read_text())
+
+
+def _find_class(tree: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name!r} not found in deepseek_v4.py")
+
+
+def _find_method(cls: ast.ClassDef, name: str):
+    for n in cls.body:
+        if isinstance(n, ast.FunctionDef) and n.name == name:
+            return n
+    return None
+
+
+def _method_src(cls: ast.ClassDef, name: str) -> str:
+    m = _find_method(cls, name)
+    if m is None:
+        return ""
+    return ast.unparse(m)
+
+
+def _method_params(cls: ast.ClassDef, name: str) -> list[str]:
+    m = _find_method(cls, name)
+    if m is None:
+        return []
+    args = m.args
+    out: list[str] = [a.arg for a in args.args]
+    out += [a.arg for a in args.kwonlyargs]
+    if args.vararg is not None:
+        out.append("*" + args.vararg.arg)
+    if args.kwarg is not None:
+        out.append("**" + args.kwarg.arg)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestForwardSignature:
+    def test_forward_accepts_forward_batch_kwarg(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        params = _method_params(cls, "forward")
+        assert "forward_batch" in params, (
+            "DeepseekV4Attention.forward must accept a forward_batch kwarg; "
+            f"got params {params}"
+        )
+
+    def test_block_forward_accepts_forward_batch_kwarg(self):
+        cls = _find_class(_tree(), "Block")
+        params = _method_params(cls, "forward")
+        assert (
+            "forward_batch" in params
+        ), f"Block.forward must accept a forward_batch kwarg; got params {params}"
+
+    def test_model_forward_accepts_forward_batch_kwarg(self):
+        cls = _find_class(_tree(), "DeepseekV4Model")
+        params = _method_params(cls, "forward")
+        # Either named arg or **kwargs that the body propagates.
+        has_forward_batch = "forward_batch" in params
+        # Inspect body for a forward_batch=... pull-through if not named.
+        src = _method_src(cls, "forward")
+        propagates_to_layer = "forward_batch=forward_batch" in src
+        assert has_forward_batch or propagates_to_layer, (
+            "DeepseekV4Model.forward must accept and propagate forward_batch; "
+            f"params={params}"
+        )
+
+
+class TestDispatch:
+    def test_attention_has_legacy_method(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        assert (
+            _find_method(cls, "_forward_legacy") is not None
+        ), "DeepseekV4Attention must expose _forward_legacy"
+
+    def test_attention_has_w4_method(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        assert (
+            _find_method(cls, "_forward_w4") is not None
+        ), "DeepseekV4Attention must expose _forward_w4"
+
+    def test_forward_dispatches_on_flag_and_forward_batch(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "forward")
+        # Flag check
+        assert (
+            "ATOM_DSV4_USE_W4_PATH" in src
+        ), "forward() must consult ATOM_DSV4_USE_W4_PATH to dispatch to W4 path"
+        # Both branches dispatched
+        assert "_forward_legacy" in src, "forward() must dispatch to _forward_legacy"
+        assert "_forward_w4" in src, "forward() must dispatch to _forward_w4"
+
+
+class TestPerTokenRoPE:
+    def test_w4_path_uses_per_token_rope(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        assert src, "_forward_w4 must exist"
+        per_token_markers = (
+            "freqs_cis[positions]",
+            "freqs_cis[forward_batch.positions]",
+        )
+        assert any(m in src for m in per_token_markers), (
+            "_forward_w4 must use per-token RoPE indexing "
+            "(freqs_cis[positions] or freqs_cis[forward_batch.positions])"
+        )
+
+    def test_w4_path_does_not_use_legacy_contiguous_slice(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        # any of these patterns indicates the legacy single-start_pos slice
+        forbidden = (
+            "start_pos : start_pos + seqlen",
+            "start_pos:start_pos + seqlen",
+            "start_pos:start_pos+seqlen",
+        )
+        for f in forbidden:
+            assert f not in src, (
+                "_forward_w4 must not use the legacy contiguous freqs_cis slice "
+                f"(found {f!r})"
+            )
+
+
+class TestKVScatter:
+    def test_w4_path_uses_compute_out_cache_loc(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        assert (
+            "compute_out_cache_loc" in src or "out_cache_loc" in src
+        ), "_forward_w4 must compute or use the per-token out_cache_loc"
+
+    def test_w4_path_uses_pool_view_for_layer(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        assert "view_for_layer" in src or "kv_pool" in src, (
+            "_forward_w4 must consume forward_batch.kv_pool / view_for_layer "
+            "instead of the legacy register_buffer kv_cache"
+        )
+
+
+class TestValidatorIntegration:
+    def test_w4_path_calls_validator(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        assert (
+            "dsv4_validate_sparse_attn_metadata" in src
+        ), "_forward_w4 must call dsv4_validate_sparse_attn_metadata"
+        assert (
+            "ATOM_AITER_VALIDATE" in src
+        ), "_forward_w4 must gate the validator on ATOM_AITER_VALIDATE"
+
+    def test_validator_called_before_sparse_attn(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        i_validator = src.find("dsv4_validate_sparse_attn_metadata")
+        i_sparse_attn = src.find("sparse_attn(")
+        assert i_validator != -1, "validator missing"
+        assert i_sparse_attn != -1, "sparse_attn call missing"
+        assert i_validator < i_sparse_attn, (
+            "Validator must be invoked before sparse_attn so OOB indices "
+            "fail with a host-side ValueError, not a GPU HSA crash"
+        )
+
+
+class TestPerTokenTopkHelper:
+    def test_helper_method_or_function_exists(self):
+        tree = _tree()
+        # method on the class
+        cls = _find_class(tree, "DeepseekV4Attention")
+        has_method = _find_method(cls, "_build_topk_per_token") is not None
+        # or module-level function
+        has_module_helper = False
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef) and node.name in (
+                "_build_topk_per_token",
+                "_get_window_topk_idxs_pertoken",
+            ):
+                has_module_helper = True
+                break
+        assert (
+            has_method or has_module_helper
+        ), "Per-token topk helper (method or module-level fn) must exist"
+
+
+class TestLegacyPreserved:
+    def test_legacy_method_signature(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        params = _method_params(cls, "_forward_legacy")
+        # _forward_legacy(self, x[, start_pos]) — must take x positionally.
+        assert (
+            "x" in params and len(params) >= 2
+        ), f"_forward_legacy must take self,x[,start_pos]; got {params}"
+
+    def test_legacy_path_body_preserves_register_buffer_kv_cache(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_legacy")
+        assert (
+            "self.kv_cache" in src
+        ), "_forward_legacy must keep self.kv_cache (the register_buffer)"
+
+    def test_attention_init_keeps_register_buffer(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "__init__")
+        # ast.unparse normalizes string quotes to single quotes, so accept
+        # either single- or double-quoted "kv_cache" literal.
+        kv_cache_literal = ("'kv_cache'" in src) or ('"kv_cache"' in src)
+        assert "register_buffer(" in src and kv_cache_literal, (
+            "DeepseekV4Attention.__init__ must keep " 'register_buffer("kv_cache", ...)'
+        )
+
+
+class TestForCausalLMForwardBatchPlumbing:
+    def test_for_causal_lm_pulls_forward_batch_from_context(self):
+        cls = _find_class(_tree(), "DeepseekV4ForCausalLM")
+        src = _method_src(cls, "forward")
+        assert (
+            "dsv4_forward_batch" in src or "forward_batch" in src
+        ), "DeepseekV4ForCausalLM.forward must wire forward_batch from ForwardContext"
+
+
+class TestBlockForwardThreadsForwardBatch:
+    def test_block_forward_threads_forward_batch_into_attn(self):
+        cls = _find_class(_tree(), "Block")
+        src = _method_src(cls, "forward")
+        # Body must pass forward_batch to self.attn(...) somewhere.
+        assert (
+            "forward_batch=forward_batch" in src
+            or "forward_batch=forward_batch," in src
+            or "forward_batch=forward_batch)" in src
+        ), "Block.forward must pass forward_batch to self.attn(...)"

--- a/tests/test_dsv4_multireq_guard.py
+++ b/tests/test_dsv4_multireq_guard.py
@@ -69,13 +69,65 @@ class TestValidateDsv4Multireq:
         _validate_dsv4_multireq(architectures=["DeepseekV4ForCausalLM"], max_num_seqs=1)
 
     def test_dsv4_arch_with_override_accepts_max_num_seqs_4(self):
-        with patch.dict(os.environ, {"ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1"}):
+        # Post-W4.3 spec: BOTH flags required (double opt-in).
+        with patch.dict(
+            os.environ,
+            {
+                "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1",
+                "ATOM_DSV4_USE_W4_PATH": "1",
+            },
+        ):
             # Re-import envs so the lazy lambda re-reads os.environ.
             import importlib
 
             from atom.utils import envs as envs_mod
 
             importlib.reload(envs_mod)
+            _validate_dsv4_multireq(
+                architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+            )
+
+    def test_unsafe_alone_now_rejects(self):
+        """Post-W4.3 spec: UNSAFE=1 alone is no longer enough — also need USE_W4_PATH=1."""
+        with patch.dict(os.environ, {"ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1"}):
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            with pytest.raises(ValueError, match="ATOM_DSV4_USE_W4_PATH"):
+                _validate_dsv4_multireq(
+                    architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+                )
+
+    def test_use_w4_alone_rejects(self):
+        with patch.dict(os.environ, {"ATOM_DSV4_USE_W4_PATH": "1"}):
+            os.environ.pop("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            with pytest.raises(ValueError, match="ATOM_DSV4_UNSAFE_MULTIREQ_DEV"):
+                _validate_dsv4_multireq(
+                    architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+                )
+
+    def test_both_flags_allow_multireq(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1",
+                "ATOM_DSV4_USE_W4_PATH": "1",
+            },
+        ):
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            # Should not raise
             _validate_dsv4_multireq(
                 architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
             )
@@ -107,14 +159,15 @@ class TestValidateDsv4Multireq:
     def test_error_message_points_users_to_remediation(self):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", None)
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
             with pytest.raises(ValueError) as exc_info:
                 _validate_dsv4_multireq(
                     architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
                 )
             msg = str(exc_info.value)
             assert "issues/37" in msg
-            assert "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1" in msg
-            assert "feat/dsv4-forward-batch-paged-kv" in msg
+            assert "ATOM_DSV4_UNSAFE_MULTIREQ_DEV" in msg
+            assert "ATOM_DSV4_USE_W4_PATH" in msg
 
 
 class TestConfigIntegration:

--- a/tests/test_dsv4_multireq_guard.py
+++ b/tests/test_dsv4_multireq_guard.py
@@ -193,3 +193,32 @@ class TestDSV4UnsafeMultireqDevEnv:
 
             importlib.reload(envs_mod)
             assert envs_mod.ATOM_DSV4_UNSAFE_MULTIREQ_DEV is False
+
+    def test_use_w4_path_default_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_DSV4_USE_W4_PATH is False
+
+    def test_use_w4_path_set_true(self):
+        with patch.dict(os.environ, {"ATOM_DSV4_USE_W4_PATH": "1"}):
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_DSV4_USE_W4_PATH is True
+
+    def test_aiter_validate_default_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ATOM_AITER_VALIDATE", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_AITER_VALIDATE is False

--- a/tests/test_modelrunner_dsv4_pool_lifecycle.py
+++ b/tests/test_modelrunner_dsv4_pool_lifecycle.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""ModelRunner is the sole owner of DSV4KVPool (issue sunway513/atom#37 P2.2).
+
+Verifies the canonical #42 fix: ``is_dummy_run`` short-circuit at the very
+entry of ``_maybe_setup_dsv4_forward_batch`` + ``ATOM_DSV4_USE_W4_PATH``
+gate. Both must pass before the pool is touched.
+
+Additionally validates:
+- pool finish_request is idempotent under preempt-then-finish race.
+- ModelRunner._build_dsv4_pool wires the pool's finish_request into
+  the scheduler's finish-listener registry (P2.2 ownership boundary).
+
+These tests do NOT exercise live cudagraph or real model construction;
+they exercise the pure pool-lifecycle helper using ``unittest.mock``.
+
+Heavy aiter / model-loader imports at the top of ``model_runner.py`` are
+stubbed below so the module is importable without GPU dependencies.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-import: stub the heavy chain that atom.model_engine.model_runner pulls
+# in at module level (aiter, model_loader, kv_transfer, etc.).
+# Must run before any `from atom.model_engine.model_runner import ModelRunner`.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    return sys.modules[name]
+
+
+def _stub_modelrunner_imports() -> None:
+    # aiter top-level: model_runner does
+    #   from aiter import destroy_dist_env, dtypes, init_dist_env
+    _aiter = _ensure_module("aiter")
+    for fn in ("destroy_dist_env", "init_dist_env"):
+        if not hasattr(_aiter, fn):
+            setattr(_aiter, fn, lambda *a, **kw: None)
+    if not hasattr(_aiter, "dtypes"):
+        _aiter.dtypes = types.SimpleNamespace()
+
+    # aiter.dist.parallel_state — extra symbols beyond conftest's stubs.
+    _ps = _ensure_module("aiter.dist.parallel_state")
+    for fn in ("get_dp_group", "get_pp_group", "get_tp_group", "graph_capture"):
+        if not hasattr(_ps, fn):
+            setattr(_ps, fn, lambda *a, **kw: None)
+
+    # aiter.dist.utils — get_distributed_init_method
+    _du = _ensure_module("aiter.dist.utils")
+    if not hasattr(_du, "get_distributed_init_method"):
+        _du.get_distributed_init_method = lambda *a, **kw: ""
+
+    # atom.model_loader.loader — load_model
+    _ml_pkg = _ensure_module("atom.model_loader")
+    _ml_pkg.__path__ = []
+    _ml = _ensure_module("atom.model_loader.loader")
+    if not hasattr(_ml, "load_model"):
+        _ml.load_model = lambda *a, **kw: None
+
+    # atom.model_ops.* — RejectionSampler, sampler, etc.
+    _mo_pkg = _ensure_module("atom.model_ops")
+    _mo_pkg.__path__ = []
+    _rj = _ensure_module("atom.model_ops.rejection_sampler")
+    if not hasattr(_rj, "RejectionSampler"):
+        _rj.RejectionSampler = type("RejectionSampler", (), {})
+    _sm = _ensure_module("atom.model_ops.sampler")
+    if not hasattr(_sm, "SAMPLER_EPS"):
+        _sm.SAMPLER_EPS = 1e-6
+    if not hasattr(_sm, "Sampler"):
+        _sm.Sampler = type("Sampler", (), {})
+
+    # atom.spec_decode.eagle — EagleProposer
+    _sd_pkg = _ensure_module("atom.spec_decode")
+    _sd_pkg.__path__ = []
+    _ea = _ensure_module("atom.spec_decode.eagle")
+    if not hasattr(_ea, "EagleProposer"):
+        _ea.EagleProposer = type("EagleProposer", (), {})
+
+    # atom.kv_transfer.disaggregation — KVConnectorOutput
+    _kt_pkg = _ensure_module("atom.kv_transfer")
+    _kt_pkg.__path__ = []
+    _dg = _ensure_module("atom.kv_transfer.disaggregation")
+    if not hasattr(_dg, "KVConnectorOutput"):
+        _dg.KVConnectorOutput = type("KVConnectorOutput", (), {})
+
+    # atom.utils submodules used by model_runner
+    _u_pkg = _ensure_module("atom.utils")
+    _u_pkg.__path__ = [
+        __import__("os").path.join(
+            __import__("os").path.dirname(__import__("os").path.dirname(__file__)),
+            "atom",
+            "utils",
+        )
+    ]
+    # tbo, selector — stub to avoid heavy chain
+    _tbo = _ensure_module("atom.utils.tbo")
+    if not hasattr(_tbo, "UBatchWrapper"):
+        _tbo.UBatchWrapper = type("UBatchWrapper", (), {})
+    if not hasattr(_tbo, "maybe_create_ubatch_slices"):
+        _tbo.maybe_create_ubatch_slices = lambda *a, **kw: None
+    _sel = _ensure_module("atom.utils.selector")
+    if not hasattr(_sel, "get_attn_backend"):
+        _sel.get_attn_backend = lambda *a, **kw: None
+
+    # atom.config — extra symbol set_current_atom_config
+    _cfg = sys.modules.get("atom.config")
+    if _cfg is not None and not hasattr(_cfg, "set_current_atom_config"):
+        _cfg.set_current_atom_config = lambda *a, **kw: None
+
+    # atom.utils.__init__ — model_runner does
+    #   from atom.utils import (CpuGpuBuffer, envs, get_hf_text_config,
+    #       init_exit_handler, resolve_obj_by_qualname)
+    if not hasattr(_u_pkg, "CpuGpuBuffer"):
+        _u_pkg.CpuGpuBuffer = type("CpuGpuBuffer", (), {})
+    if not hasattr(_u_pkg, "envs"):
+        from atom.utils import envs as _envs
+
+        _u_pkg.envs = _envs
+    if not hasattr(_u_pkg, "get_hf_text_config"):
+        _u_pkg.get_hf_text_config = lambda cfg: cfg
+    if not hasattr(_u_pkg, "init_exit_handler"):
+        _u_pkg.init_exit_handler = lambda *a, **kw: None
+    if not hasattr(_u_pkg, "resolve_obj_by_qualname"):
+        _u_pkg.resolve_obj_by_qualname = lambda name: None
+    # graph_marker referenced by model_runner.__init__
+    _gm = _ensure_module("atom.utils.graph_marker")
+    if not hasattr(_gm, "set_graph_marker_enabled"):
+        _gm.set_graph_marker_enabled = lambda *a, **kw: None
+
+
+_stub_modelrunner_imports()
+
+
+# ---------------------------------------------------------------------------
+# Pool gating tests — the canonical #42 fix
+# ---------------------------------------------------------------------------
+
+
+class TestPoolGating:
+    def test_dummy_run_returns_none_none(self, monkeypatch):
+        """The canonical #42 fix: is_dummy_run short-circuits before pool admit."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        monkeypatch.setenv("ATOM_DSV4_USE_W4_PATH", "1")
+        # reload envs to pick up the new value
+        from atom.utils import envs as envs_mod
+
+        importlib.reload(envs_mod)
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = True
+        runner._dsv4_pool = MagicMock()  # if already inited
+
+        dummy_batch = MagicMock()
+        dummy_batch.is_dummy_run = True
+        dummy_batch.req_ids = [0, 1, 2, 3]
+
+        # Bind the real method to the mock
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            dummy_batch,
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+        # Critical: pool admit_request must NOT have been called
+        runner._dsv4_pool.admit_request.assert_not_called()
+
+    def test_flag_off_returns_none_none(self, monkeypatch):
+        """``ATOM_DSV4_USE_W4_PATH=0`` => also short-circuit."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        monkeypatch.setenv("ATOM_DSV4_USE_W4_PATH", "0")
+        from atom.utils import envs as envs_mod
+
+        importlib.reload(envs_mod)
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = True
+
+        real_batch = MagicMock()
+        real_batch.is_dummy_run = False
+        real_batch.req_ids = [0, 1]
+
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            real_batch,
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+
+    def test_non_dsv4_model_returns_none_none(self):
+        """Non-DSV4 models pass through untouched."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = False
+
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            batch=MagicMock(),
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+
+
+# ---------------------------------------------------------------------------
+# finish_request idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestFinishIdempotent:
+    def test_pool_finish_called_twice_is_safe(self):
+        """ModelRunner subscribes pool.finish_request to scheduler events.
+        finish_request must be idempotent under preempt-then-finish race.
+        """
+        import torch
+
+        from atom.engine.kv_pool.dsv4_pool import DSV4KVPool, DSV4KVPoolConfig
+
+        ratios = [4, 4, 128, 128]
+        cfg = DSV4KVPoolConfig(
+            max_active_seqs=4,
+            num_layers=4,
+            num_c4_layers=2,
+            num_c128_layers=2,
+            head_dim=32,
+            rope_head_dim=16,
+            window_size=32,
+            max_seq_len=128,
+            ring_size_main=32,
+            ring_size_compressor=8,
+            ring_size_indexer=32,
+            compress_ratio_per_layer=ratios,
+            state_inner_dim=32,
+            dtype=torch.float32,
+            state_dtype=torch.float32,
+            device=torch.device("cpu"),
+        )
+        pool = DSV4KVPool(cfg)
+        pool.admit_request(seq_id=0)
+        pool.finish_request(seq_id=0)
+        # Second call must not raise (idempotent)
+        pool.finish_request(seq_id=0)
+        # Third call also OK (never admitted; defensive no-op)
+        pool.finish_request(seq_id=999)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler subscription wiring (structural smoke check)
+# ---------------------------------------------------------------------------
+
+
+class TestNoDsv4ScheduleListener:
+    def test_modelrunner_subscribes_pool_to_scheduler(self):
+        """The wiring: ``ModelRunner._build_dsv4_pool`` source must reference
+        ``register_finish_listener`` (preferred) or at least the scheduler.
+
+        Smoke-style assertion since constructing a full ModelRunner+Scheduler
+        integration is too heavy for a unit test.
+        """
+        import inspect
+
+        from atom.model_engine.model_runner import ModelRunner
+
+        if hasattr(ModelRunner, "_build_dsv4_pool"):
+            src = inspect.getsource(ModelRunner._build_dsv4_pool)
+            assert "register_finish_listener" in src or "scheduler" in src.lower()
+        else:
+            pytest.skip("_build_dsv4_pool not yet implemented")

--- a/tests/test_scheduler_lifecycle_events.py
+++ b/tests/test_scheduler_lifecycle_events.py
@@ -1,0 +1,64 @@
+"""Scheduler emits seq lifecycle events via callback registry (issue #37 W4.3 P2.2).
+
+Establishes the ownership boundary: Scheduler does not know DSV4KVPool
+exists; ModelRunner subscribes pool.admit_request / pool.finish_request
+to these events.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestEventRegistry:
+    def test_admit_listener_registry_exists(self, scheduler):
+        """Public API: register_admit_listener(fn) appends fn to the registry."""
+        listener = MagicMock()
+        scheduler.register_admit_listener(listener)
+        assert listener in scheduler._admit_listeners
+
+    def test_finish_listener_registry_exists(self, scheduler):
+        listener = MagicMock()
+        scheduler.register_finish_listener(listener)
+        assert listener in scheduler._finish_listeners
+
+    def test_emit_admit_calls_all_admit_listeners(self, scheduler):
+        l1, l2 = MagicMock(), MagicMock()
+        scheduler.register_admit_listener(l1)
+        scheduler.register_admit_listener(l2)
+        scheduler._emit_admit(seq_id=42)
+        l1.assert_called_once_with(42)
+        l2.assert_called_once_with(42)
+
+    def test_emit_finish_calls_all_finish_listeners(self, scheduler):
+        l1, l2 = MagicMock(), MagicMock()
+        scheduler.register_finish_listener(l1)
+        scheduler.register_finish_listener(l2)
+        scheduler._emit_finish(seq_id=99)
+        l1.assert_called_once_with(99)
+        l2.assert_called_once_with(99)
+
+    def test_listener_exception_does_not_propagate(self, scheduler):
+        """A bad listener cannot break the scheduler."""
+        bad = MagicMock(side_effect=RuntimeError("oops"))
+        good = MagicMock()
+        scheduler.register_admit_listener(bad)
+        scheduler.register_admit_listener(good)
+        # Must not raise
+        scheduler._emit_admit(seq_id=1)
+        good.assert_called_once_with(1)
+
+
+class TestNoDsv4PoolImport:
+    def test_scheduler_source_does_not_reference_dsv4_pool(self):
+        """Ownership boundary check: scheduler.py must not import DSV4KVPool.
+
+        ModelRunner subscribes the pool's admit/finish methods to the
+        scheduler's events. The scheduler itself is pool-agnostic.
+        """
+        import atom.model_engine.scheduler as sched_mod
+
+        with open(sched_mod.__file__) as f:
+            src = f.read()
+        # The scheduler may have generic listener bookkeeping but must not
+        # know about DSV4KVPool specifically.
+        assert "DSV4KVPool" not in src
+        assert "dsv4_pool" not in src.lower()


### PR DESCRIPTION
## Summary

Largest task of Sprint 1 (issue sunway513/atom#37 W4.3-redo Task 10). Wires `DeepseekV4Attention.forward` to consume `DSV4ForwardBatch` + `DSV4KVPool` when both feature flags are set, while preserving the legacy single-request path bit-for-bit when flags are off.

Built on Tasks 6+7 (env vars + guard), Task 8 (scheduler events), Task 9 (ModelRunner+ForwardContext) — all merged into this branch.

## Dispatch contract

```
forward_batch is None OR ATOM_DSV4_USE_W4_PATH=0   ->  _forward_legacy
                                                       (post-#44 main behavior, bit-for-bit)
forward_batch present AND ATOM_DSV4_USE_W4_PATH=1  ->  _forward_w4
                                                       (per-token RoPE,
                                                        per-seq slot KV scatter,
                                                        validator gate)
```

## What

- New `_forward_legacy` (verbatim copy of pre-W4.3-redo `forward()` body — do not refactor).
- New `_forward_w4` (W4 multi-request path):
  - Per-token RoPE: `self.freqs_cis[positions]` (the W3.2-v5 wall fix).
  - Per-token KV scatter via `DSV4KVPool.compute_out_cache_loc(...)` into the per-layer pool view.
  - Per-token sparse_attn read: each token attends to its OWN seq's pool slot (no row-0 collision).
  - Validator gate (`dsv4_validate_sparse_attn_metadata`) immediately before sparse_attn when `ATOM_AITER_VALIDATE=1`.
- New `_build_topk_per_token` helper (delegates to module fn `_get_window_topk_idxs_pertoken`, adapted from W3.2-v6 archive).
- `Block` / `MTPBlock` / `DeepseekV4Model` / `DeepseekV4ForCausalLM` forward signatures threaded with optional `forward_batch`.
- `DeepseekV4ForCausalLM.forward` auto-pulls `forward_batch` from `ForwardContext.dsv4_forward_batch` (populated by Task 9's ModelRunner) when not passed explicitly.
- `register_buffer("kv_cache", ...)` deliberately preserved in `DeepseekV4Attention.__init__` for the legacy fallback path. Comment added explaining the contract.

## Why this won't repeat the PR #42 silicon crash

The HSA crash on PR #42 was caused by warmup synthetic tensors entering the W4 path — fixed in Task 9 by the `is_dummy_run` short-circuit at the very entry of `ModelRunner._maybe_setup_dsv4_forward_batch`. The attention math itself was correct on PR #42 (80 UT passed). This Task 10 reuses that math, validated by the AITER metadata validator before kernel launch.

## Test plan

- [x] 215 cumulative UT PASS across:
  - `test_deepseek_v4_w43_redo.py` (18 new, AST-level contract)
  - `test_dsv4_pool.py` / `test_dsv4_forward_batch.py` / `test_dsv4_multireq_guard.py`
  - `test_scheduler_lifecycle_events.py` / `test_modelrunner_dsv4_pool_lifecycle.py`
  - `test_block_manager*.py` / `test_kv_cache_interface.py`
  - `test_scheduler.py` / `test_sequence*.py`
- [x] `ruff check` + `black --check` clean on both modified files.
- [x] Static checks: `_forward_w4` calls `dsv4_validate_sparse_attn_metadata` (gated on `ATOM_AITER_VALIDATE`) BEFORE `sparse_attn`.
- [x] Static check: `_forward_w4` uses `freqs_cis[positions]` per-token RoPE; legacy contiguous slice forbidden.
- [x] Static check: `_forward_legacy` keeps `self.kv_cache` reference; init keeps `register_buffer("kv_cache", ...)`.

## Out of scope (covered by Tasks 11/12)

- Compressor state migration to pool (W4.4-redo) — Task 11
- Indexer state migration to pool — Task 12
- Silicon validation at conc=4 on real DSV4 checkpoint — Task 14

## References

- sunway513/atom#37 W4.3-redo Task 10
- Spec `docs/superpowers/specs/2026-04-26-dsv4-w43-redo-aiter-track-design.md` sections 3 + 4
- AITER validator: `aiter/dsv4_validate.py`
- W3.2-v6 archive (per-token topk math reference): `feat/dsv4-v6-experimental`
- PR #42 archive (reference attention math, reverted only due to ModelRunner warmup bug fixed in Task 9): commit `f3ae4ec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)