### PR TITLE
[W4.4-redo] DSV4 Compressor + Indexer state migration to pool (#37 Tasks 11+12)

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1748,6 +1748,164 @@ class ModelRunner:
         num_input_tokens = int(torch.max(num_tokens_across_dp).item())
         return num_input_tokens, num_tokens_across_dp, reqs_across_dp
 
+    # ------------------------------------------------------------------
+    # DSV4 W4 path helpers (issue sunway513/atom#37 P2.2 — W4.3-redo Task 9)
+    # ------------------------------------------------------------------
+
+    def _is_dsv4_model(self) -> bool:
+        """Detect DSV4 architectures from ``hf_config.architectures``.
+
+        Centralized so callers don't sprinkle string comparisons across
+        the codebase. Mirrors the multi-request guard used in
+        ``atom.utils.dsv4_guard``.
+        """
+        archs = getattr(self.config.hf_config, "architectures", None) or []
+        from atom.utils.dsv4_guard import is_dsv4_arch
+
+        return is_dsv4_arch(archs)
+
+    def _maybe_setup_dsv4_forward_batch(self, batch, attn_metadata, positions):
+        """W4.3-redo (issue #37): lazy-init pool, admit slots, build DSV4ForwardBatch.
+
+        Critical contract: ``is_dummy_run`` short-circuit at the VERY
+        entry. Warmup runs ``MAX_BATCHED_TOKENS``-sized synthetic tensors
+        that crash the W4 path with HSA exception 0x1016 (#37 Evidence
+        I / I' / I''). Only safe behavior is to fall through to the
+        legacy single-request path by returning ``(None, None)``.
+
+        Also short-circuits if ``ATOM_DSV4_USE_W4_PATH`` is unset — pool
+        allocation is harmless but admitting seqs without the flag would
+        leak slots and reorder kernels under the wrong feature gate.
+
+        Returns
+        -------
+        ``(pool, forward_batch)`` — both ``None`` if W4 path is not
+        active for this step, so callers can pass straight to
+        ``set_forward_context`` without further branching.
+        """
+        if not self._is_dsv4_model():
+            return None, None
+
+        # CRITICAL: must be first check after arch detection. This is the
+        # canonical fix for issue #42 — warmup synthetic tensors must NOT
+        # enter the W4 path.
+        if batch is not None and getattr(batch, "is_dummy_run", False):
+            return None, None
+
+        from atom.utils import envs
+
+        if not envs.ATOM_DSV4_USE_W4_PATH:
+            return None, None
+
+        if getattr(self, "_dsv4_pool", None) is None:
+            self._dsv4_pool = self._build_dsv4_pool()
+
+        # Admit any seqs in this batch the pool hasn't seen yet. Idempotent
+        # under re-admit (DSV4KVPool.admit_request returns the same slot).
+        seq_ids: list[int] = []
+        if batch is not None:
+            seq_ids = list(batch.req_ids)
+            for sid in seq_ids:
+                self._dsv4_pool.admit_request(sid)
+
+        forward_batch = None
+        if attn_metadata is not None and positions is not None:
+            try:
+                from atom.utils.dsv4_forward_batch import DSV4ForwardBatch
+
+                forward_batch = DSV4ForwardBatch.from_attn_metadata(
+                    attn_metadata,
+                    positions,
+                    seq_ids=seq_ids if seq_ids else None,
+                    pool=self._dsv4_pool,
+                )
+            except Exception as e:
+                logger.warning(
+                    "DSV4: failed to build ForwardBatch (%s); "
+                    "falling back to legacy path",
+                    e,
+                )
+                forward_batch = None
+
+        return self._dsv4_pool, forward_batch
+
+    def _build_dsv4_pool(self):
+        """Allocate a DSV4KVPool sized from the loaded model.
+
+        Reads layer count, head dim, window size, compress ratios, etc.
+        from the model's ``DeepseekV4Args`` dataclass. One pool per
+        ModelRunner = one per TP rank. If the runner has access to a
+        scheduler instance (``self.scheduler``), subscribes
+        ``pool.finish_request`` to the scheduler's finish-listener
+        registry — this is the P2.2 ownership boundary: the scheduler
+        stays pool-agnostic and the pool stays unaware of seq lifecycle
+        events except through the registered listener.
+        """
+        from atom.engine.kv_pool.dsv4_pool import DSV4KVPool, DSV4KVPoolConfig
+
+        args = self.model.args  # DeepseekV4Args
+
+        # Per-layer compress ratios. Prefer the canonical ``compress_ratios``
+        # tuple on DeepseekV4Args; fall back to an alternating 4/128 default
+        # for synthetic test models that don't populate it.
+        n_layers = args.n_layers
+        compress_ratios = getattr(args, "compress_ratios", ()) or ()
+        compress_ratio_per_layer: list[int] = []
+        for layer_idx in range(n_layers):
+            if layer_idx < len(compress_ratios):
+                r = int(compress_ratios[layer_idx])
+            else:
+                r = 128 if layer_idx % 2 == 0 else 4
+            compress_ratio_per_layer.append(r)
+        n_c4 = sum(1 for r in compress_ratio_per_layer if r == 4)
+        n_c128 = sum(1 for r in compress_ratio_per_layer if r == 128)
+
+        # Ring sizes mirror SGLang's get_compress_state_ring_size (4→8, 128→128).
+        ring_size_compressor = 2 * 4
+        ring_size_indexer = 2 * 64
+        ring_size_main = max(getattr(args, "window_size", 128), 64)
+
+        cfg = DSV4KVPoolConfig(
+            max_active_seqs=self.config.max_num_seqs,
+            num_layers=n_layers,
+            num_c4_layers=n_c4,
+            num_c128_layers=n_c128,
+            head_dim=args.head_dim,
+            rope_head_dim=getattr(args, "rope_head_dim", args.head_dim // 2),
+            window_size=getattr(args, "window_size", 128),
+            max_seq_len=getattr(args, "max_seq_len", 4096),
+            ring_size_main=ring_size_main,
+            ring_size_compressor=ring_size_compressor,
+            ring_size_indexer=ring_size_indexer,
+            compress_ratio_per_layer=compress_ratio_per_layer,
+            dtype=self.config.torch_dtype,
+            device=self.device,
+        )
+        pool = DSV4KVPool(cfg)
+
+        # P2.2 ownership boundary: subscribe pool's finish_request to the
+        # scheduler's finish events when one is reachable from the runner.
+        # In ATOM today the scheduler lives in EngineCore (parent process)
+        # while ModelRunner runs in a child process, so this branch is a
+        # no-op in production; it exists for in-process integration tests
+        # that hand a scheduler reference to the runner. The wiring shape
+        # is the canonical one — Scheduler stays pool-agnostic.
+        scheduler = getattr(self, "scheduler", None)
+        if scheduler is not None and hasattr(scheduler, "register_finish_listener"):
+            scheduler.register_finish_listener(pool.finish_request)
+
+        logger.info(
+            "DSV4 KV pool: n_layers=%d c4=%d c128=%d max_active_seqs=%d "
+            "window=%d device=%s",
+            n_layers,
+            n_c4,
+            n_c128,
+            cfg.max_active_seqs,
+            cfg.window_size,
+            cfg.device,
+        )
+        return pool
+
     def prepare_inputs(self, batch: ScheduledBatch, input_ids: torch.Tensor = None):
         is_prefill = batch.total_tokens_num_prefill > 0
         bs = batch.total_seqs_num
@@ -1812,6 +1970,14 @@ class ModelRunner:
             reqs_across_dp,
         )
 
+        # W4.3-redo (issue #37 P2.2): set up DSV4 W4-path pool + ForwardBatch
+        # if and only if (a) model is DSV4, (b) batch is not a dummy warmup,
+        # and (c) ATOM_DSV4_USE_W4_PATH is enabled. Returns (None, None)
+        # otherwise so the legacy single-request fallback path runs.
+        dsv4_pool, dsv4_forward_batch = self._maybe_setup_dsv4_forward_batch(
+            batch, attn_metadata, positions
+        )
+
         set_forward_context(
             attn_metadata=attn_metadata,
             atom_config=self.config,
@@ -1820,6 +1986,8 @@ class ModelRunner:
             num_tokens_across_dp=num_tokens_across_dp,
             spec_decode_metadata=spec_decode_metadata,
             ubatch_slices=ubatch_slices,
+            dsv4_pool=dsv4_pool,
+            dsv4_forward_batch=dsv4_forward_batch,
         )
         return graph_bs
 

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -397,6 +397,40 @@ class Scheduler:
 
         self.kv_connector = get_kvconnector("scheduler", config)
 
+        # W4.3 (issue #37 P2.2): seq lifecycle event registry. ModelRunner
+        # subscribes its KV pool admit/finish methods here. Scheduler is
+        # pool-agnostic — it must not import or reference any concrete pool.
+        self._admit_listeners: list = []
+        self._finish_listeners: list = []
+
+    def register_admit_listener(self, fn) -> None:
+        """Subscribe a callable(seq_id: int) -> None to be invoked on admit.
+
+        Used by ModelRunner to wire pool admit_request without leaking
+        pool dependencies into the scheduler.
+        """
+        self._admit_listeners.append(fn)
+
+    def register_finish_listener(self, fn) -> None:
+        """Subscribe a callable(seq_id: int) -> None to be invoked on finish/preempt."""
+        self._finish_listeners.append(fn)
+
+    def _emit_admit(self, seq_id: int) -> None:
+        for listener in self._admit_listeners:
+            try:
+                listener(seq_id)
+            except Exception as e:
+                logger.warning("Seq admit listener %s raised %s; ignoring", listener, e)
+
+    def _emit_finish(self, seq_id: int) -> None:
+        for listener in self._finish_listeners:
+            try:
+                listener(seq_id)
+            except Exception as e:
+                logger.warning(
+                    "Seq finish listener %s raised %s; ignoring", listener, e
+                )
+
     def is_finished(self):
         return not self.waiting and not self.running
 
@@ -467,6 +501,7 @@ class Scheduler:
                 seq.status = SequenceStatus.RUNNING
                 seq.is_first_decode = True
                 self.running.append(seq)
+                self._emit_admit(seq.id)
                 continue
 
             num_seqs_prefill += 1
@@ -479,6 +514,7 @@ class Scheduler:
             self.running.append(seq)
             scheduled_seqs[seq.id] = seq
             num_scheduled_tokens.append(num_new_tokens)
+            self._emit_admit(seq.id)
 
         if skipped_waiting_requests:
             logger.debug(
@@ -577,6 +613,8 @@ class Scheduler:
         seq.spec_token_ids = np.array([], dtype=np.int32)
         self.block_manager.deallocate(seq)
         self.waiting.appendleft(seq)
+        # Notify lifecycle subscribers: seq is no longer running.
+        self._emit_finish(seq.id)
 
     def postprocess(
         self,
@@ -729,6 +767,8 @@ class Scheduler:
             else:
                 self.block_manager.deallocate(seq)
             self.running.remove(seq)
+            # Notify lifecycle subscribers: seq has finished.
+            self._emit_finish(seq.id)
         return finished_seqs
 
     def _update_waiting_for_remote_kv(self, seq: Sequence) -> bool:

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -399,6 +399,84 @@ def _get_window_topk_idxs(
     return matrix.unsqueeze(0).expand(bsz, -1, -1)
 
 
+def _get_window_topk_idxs_pertoken(
+    window_size: int,
+    positions: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    device: Optional[torch.device] = None,
+) -> torch.Tensor:
+    """Per-token sliding-window topk indices for multi-seq packed batches.
+
+    W4.3-redo (issue sunway513/atom#37): the cached
+    ``_get_window_topk_idxs`` helper above assumes a single ``start_pos``
+    scalar per call — fine for the legacy B=1-implicit single-sequence
+    path, but fundamentally wrong when N different sequences have N
+    different per-seq positions in the same packed batch. This per-token
+    variant builds one row per token using the token's actual absolute
+    ``positions[t]`` value, eliminating the cross-talk that the W3.2
+    v3..v6.1 archive chain repeatedly tried to patch around.
+
+    Args
+    ----
+    window_size: ring size of the sliding-window KV cache.
+    positions: ``[num_tokens]`` long, absolute token positions
+        (``DSV4ForwardBatch.positions``).
+    cu_seqlens_q: ``[num_seqs+1]`` long, cumulative-tokens-per-seq
+        prefix sum. Used to derive each token's in-seq offset so prefill
+        rows still span only the seq's own keys.
+    device: target device for the returned tensor.
+
+    Returns
+    -------
+    ``[num_tokens, window_size]`` int64 tensor where ``-1`` marks a
+    masked (causal-future) slot. Caller is expected to ``unsqueeze(0)``
+    for the legacy 3D ``[1, T, K]`` shape.
+
+    Semantics
+    ---------
+    - Decode token (one new token per seq, position p):
+      ``out[t] = [(p+1) % W, (p+2) % W, ..., (p+W) % W]``  modulo window
+      — the row matches what the legacy helper produced for that single
+      seq.
+    - Prefill token within a seq (positions 0..S-1): mirrors the legacy
+      helper's ``else`` branch (causal mask) — each query at offset i
+      sees only positions ``[max(0, i-W+1) .. i]``.
+
+    Both branches are unified by computing each row from its absolute
+    ``positions[t]`` and the per-seq starting position, regardless of
+    whether the seq is in prefill or decode.
+    """
+    if device is None:
+        device = positions.device
+    T = positions.numel()
+    W = window_size
+    if T == 0:
+        return torch.zeros(0, W, dtype=torch.long, device=device)
+
+    cu_long = cu_seqlens_q.to(device=device, dtype=torch.long)
+    # token_idx → seq_idx via right-bucketize on cu[1:].
+    token_idx = torch.arange(T, dtype=torch.long, device=device)
+    seg_id = torch.bucketize(token_idx, cu_long[1:], right=True)
+    seq_starts = cu_long[seg_id]  # first token-idx of this token's seq
+    in_seq_offset = token_idx - seq_starts  # 0-based within the seq
+
+    pos = positions.to(device=device, dtype=torch.long)
+    # Per-token row template:
+    #   out[t, k] = (start_p + k) % W,  start_p = pos[t] - in_seq_offset[t]
+    # plus a causal mask on the early prefill rows.
+    arange_w = torch.arange(W, dtype=torch.long, device=device)
+
+    # Rotated window for "fully-warm" tokens (pos >= W-1): unrolled with
+    # the modular arithmetic used by `_get_window_topk_idxs`'s warm
+    # branch, this is identical. Early-prefill (pos < W-1) → invalid
+    # future slots = -1.
+    base = pos.unsqueeze(1) - in_seq_offset.unsqueeze(1) + arange_w.unsqueeze(0)
+    ring_idx = base % W
+    valid = (base >= 0) & (base <= pos.unsqueeze(1))
+    out = torch.where(valid, ring_idx, torch.full_like(ring_idx, -1))
+    return out
+
+
 @lru_cache(2)
 def _get_compress_topk_idxs(
     ratio: int,
@@ -985,6 +1063,12 @@ class DeepseekV4Attention(nn.Module):
             self.indexer = None
 
         # ----- KV cache: [B, window_size + max_seq_len/ratio, head_dim] -----
+        # Legacy single-request kv_cache. The W4 path
+        # (forward_batch != None && ATOM_DSV4_USE_W4_PATH=1) consumes a
+        # per-layer view of the engine-owned ``DSV4KVPool`` instead. This
+        # buffer is preserved verbatim so the bit-for-bit legacy fallback
+        # path (warmup, single-seq eager, PR1 toy validation) still works
+        # exactly as it did post-#44 main.
         kv_cache_size = args.window_size + (
             args.max_seq_len // self.compress_ratio if self.compress_ratio else 0
         )
@@ -1091,16 +1175,55 @@ class DeepseekV4Attention(nn.Module):
 
         self.wo_a.quant_type = _QT.No
 
-    def forward(self, x: torch.Tensor, start_pos: int) -> torch.Tensor:
-        """Compute attention for `x` at absolute position `start_pos`.
+    def forward(
+        self,
+        x: torch.Tensor,
+        start_pos: int = 0,
+        forward_batch: Optional[Any] = None,
+    ) -> torch.Tensor:
+        """W4.3-redo (issue sunway513/atom#37): dispatch on flag + forward_batch.
+
+        Two operating modes:
+
+        - **Legacy single-request path** (``_forward_legacy``):
+          ``forward_batch is None`` OR ``ATOM_DSV4_USE_W4_PATH=0``. The
+          pre-W4.3-redo body is preserved bit-for-bit so warmup,
+          single-seq eager, and PR1 toy validation behave exactly as
+          they did post-#44 main.
+
+        - **W4 multi-request path** (``_forward_w4``): both
+          ``forward_batch is not None`` AND ``ATOM_DSV4_USE_W4_PATH=1``.
+          Per-token RoPE, per-seq slot KV scatter via the engine
+          ``DSV4KVPool``, validator gate before ``sparse_attn``.
 
         Args:
-            x: [num_tokens, dim] flat ATOM convention. Single-sequence
+            x: ``[num_tokens, dim]`` flat ATOM convention.
+            start_pos: legacy scalar position (only used in legacy path).
+            forward_batch: optional ``DSV4ForwardBatch`` carrying per-step
+                multi-request metadata.
+        Returns:
+            ``[num_tokens, dim]`` attention output (BF16).
+        """
+        from atom.utils import envs
+
+        if forward_batch is None or not envs.ATOM_DSV4_USE_W4_PATH:
+            return self._forward_legacy(x, start_pos)
+        return self._forward_w4(x, forward_batch)
+
+    def _forward_legacy(self, x: torch.Tensor, start_pos: int = 0) -> torch.Tensor:
+        """Legacy single-request path. Bit-for-bit preserved post-#44.
+
+        This is the entire pre-W4.3-redo ``forward()`` body, copied
+        verbatim. Do not optimize, refactor, or "improve" — bit-for-bit
+        preservation under flag-off is the contract.
+
+        Args:
+            x: ``[num_tokens, dim]`` flat ATOM convention. Single-sequence
                 (B=1 implicit; multi-sequence batching needs attn_metadata,
-                deferred until ATOM's scheduler integration).
+                handled by ``_forward_w4`` instead).
             start_pos: absolute position of the first token in this batch.
         Returns:
-            [num_tokens, dim] attention output (BF16).
+            ``[num_tokens, dim]`` attention output (BF16).
         """
         assert (
             x.dim() == 2
@@ -1237,6 +1360,168 @@ class DeepseekV4Attention(nn.Module):
 
         # ----- Grouped output LoRA -----
         # o: [1, S, H, D] → drop B; reshape into groups for the einsum.
+        o = o.squeeze(0).view(seqlen, self.n_local_groups, -1)  # [S, g, H/g * D]
+        wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
+        o = torch.einsum("sgd,grd->sgr", o, wo_a)  # [S, g, o_lora_rank]
+        x = self.wo_b(o.flatten(1))  # 2D [S, dim]
+        return x
+
+    def _build_topk_per_token(self, forward_batch: Any) -> torch.Tensor:
+        """Build per-token sliding-window topk_idxs for the W4 path.
+
+        Adapts the W3.2-v6 archive's per-token math to the
+        ``DSV4ForwardBatch`` shape (``positions`` + ``cu_seqlens_q``).
+
+        Returns
+        -------
+        ``[1, num_tokens, window_size]`` int64 tensor (the leading ``B=1``
+        dim matches the legacy ``[1, N, K]`` shape downstream code
+        expects). Sentinels: ``-1`` marks causal-future / invalid slots.
+        """
+        return _get_window_topk_idxs_pertoken(
+            self.window_size,
+            forward_batch.positions,
+            forward_batch.cu_seqlens_q,
+            device=forward_batch.positions.device,
+        ).unsqueeze(0)
+
+    def _forward_w4(
+        self,
+        x: torch.Tensor,
+        forward_batch: Any,
+    ) -> torch.Tensor:
+        """W4 multi-request path (issue sunway513/atom#37).
+
+        Per-token RoPE via ``self.freqs_cis[positions]``, per-seq slot
+        KV scatter via ``DSV4KVPool.compute_out_cache_loc``, validator
+        gate (``ATOM_AITER_VALIDATE``) before ``sparse_attn``. Each
+        token's query attends to its OWN seq's slot row in the pool,
+        eliminating the row-0 collision class of bugs documented in
+        W3.2 v3..v6.1.
+
+        Compressor / Indexer state remains ``register_buffer``-owned in
+        Task 10 (lifted to the pool by Tasks 11/12). The W4 path here
+        skips compressor/indexer activations and uses window-only
+        topk_idxs. Compressed-attention multi-request prefill is
+        explicitly out of scope until Tasks 11/12.
+
+        Args:
+            x: ``[num_tokens, dim]`` flat ATOM convention.
+            forward_batch: ``DSV4ForwardBatch`` (must carry a non-None
+                ``kv_pool``).
+        Returns:
+            ``[num_tokens, dim]`` attention output (BF16).
+        """
+        from atom.utils import envs
+
+        assert (
+            x.dim() == 2
+        ), f"DeepseekV4Attention expects 2D [num_tokens, dim], got {x.shape}"
+        assert (
+            forward_batch.kv_pool is not None
+        ), "_forward_w4 requires a non-None forward_batch.kv_pool"
+
+        positions = forward_batch.positions  # [num_tokens] long
+        rd = self.rope_head_dim
+
+        # Per-layer pool view: [num_active_seqs, ring_main, head_dim].
+        # Zero-copy slice; rebound every step.
+        pool_view = forward_batch.kv_pool.view_for_layer(self.layer_id)
+        kv_cache_view = pool_view["kv_cache"]
+        n_slots, ring_main, head_dim = kv_cache_view.shape
+
+        # ---- Per-token RoPE (CRITICAL — was the W3.2-v5 wall) ----
+        # Gather one row per token by absolute position. Under
+        # multi-request decode, the N tokens in a packed batch belong to
+        # N distinct seqs at N distinct positions; the legacy
+        # `freqs_cis[start_pos:start_pos+seqlen]` contiguous slice
+        # silently gave every seq the same frequency.
+        freqs_cis = self.freqs_cis[positions]
+
+        # ---- Q: low-rank projection + per-head RMSNorm + partial RoPE ----
+        seqlen = x.size(0)
+        qr = self.q_norm(self.wq_a(x))  # [seqlen, q_lora_rank]
+        q = self.wq_b(qr).view(seqlen, self.n_local_heads, self.head_dim)
+        q = q * torch.rsqrt(q.square().mean(-1, keepdim=True) + self.eps)
+        q = q.unsqueeze(0)  # [1, seqlen, H, D]
+        _apply_rotary_emb(q[..., -rd:], freqs_cis)
+
+        # ---- KV: project, RMSNorm, RoPE on rope dims, FP8-sim on nope ----
+        kv = self.wkv(x)  # [seqlen, head_dim]
+        kv = self.kv_norm(kv).unsqueeze(0)  # [1, seqlen, head_dim]
+        _apply_rotary_emb(kv[..., -rd:], freqs_cis)
+        act_quant_inplace(kv[..., :-rd], 64, self.scale_fmt)
+
+        # ---- Per-token slot scatter into the pool's main ring ----
+        if forward_batch.out_cache_loc is not None:
+            out_cache_loc = forward_batch.out_cache_loc.to(
+                device=x.device, dtype=torch.long
+            )
+        else:
+            out_cache_loc = forward_batch.kv_pool.compute_out_cache_loc(
+                positions=positions,
+                slot_indices=forward_batch.req_pool_indices,
+                cu_seqlens_q=forward_batch.cu_seqlens_q,
+                ring="main",
+            )
+        kv_tok = kv.squeeze(0)  # [num_tokens, head_dim]
+        # Flatten the [N, ring_main, D] pool view to [N*ring_main, D] for
+        # scatter. Zero-copy reshape — pool storage is contiguous.
+        kv_flat = kv_cache_view.view(n_slots * ring_main, head_dim)
+        # Cast scatter source to pool dtype to avoid silent zero-out from
+        # an implicit dtype-mismatch copy_.
+        kv_flat[out_cache_loc] = kv_tok.to(kv_flat.dtype)
+
+        # ---- Per-token window topk_idxs ----
+        topk_idxs = self._build_topk_per_token(forward_batch)  # [1, T, win] int64
+        topk_idxs = topk_idxs.int()
+
+        # ---- Build per-token KV slabs: each token attends to its OWN
+        # seq's pool row. ----
+        num_tokens = kv_tok.shape[0]
+        token_idx = torch.arange(num_tokens, dtype=torch.long, device=x.device)
+        cu_long = forward_batch.cu_seqlens_q.to(device=x.device, dtype=torch.long)
+        seg_id = torch.bucketize(token_idx, cu_long[1:], right=True)
+        slot_per_token = forward_batch.req_pool_indices.to(
+            device=x.device, dtype=torch.long
+        )[seg_id]
+        kv_per_token = kv_cache_view[slot_per_token]  # [T, ring_main, D]
+        q_per_token = q.transpose(0, 1).contiguous()  # [T, 1, H, D]
+        topk_per_token = topk_idxs.transpose(0, 1).contiguous()  # [T, 1, K]
+
+        # ---- Validator gate: catch shape/dtype/OOB BEFORE the GPU kernel ----
+        if envs.ATOM_AITER_VALIDATE:
+            try:
+                from aiter.dsv4_validate import dsv4_validate_sparse_attn_metadata
+
+                dsv4_validate_sparse_attn_metadata(
+                    q=q_per_token,
+                    kv=kv_per_token,
+                    topk_idxs=topk_per_token,
+                    slot_mapping=out_cache_loc,
+                    positions=positions,
+                    cu_seqlens_q=forward_batch.cu_seqlens_q,
+                    pool_capacity=n_slots,
+                )
+            except ImportError:
+                # Validator not available in this aiter build — proceed
+                # without it. ATOM_AITER_VALIDATE is opt-in for debug.
+                pass
+
+        # ---- sparse_attn (W4 per-token call: B=num_tokens, M=1) ----
+        o = sparse_attn(
+            q_per_token,
+            kv_per_token,
+            self.attn_sink,
+            topk_per_token,
+            self.softmax_scale,
+        )
+        o = o.transpose(0, 1).contiguous()  # back to [1, T, H, D]
+
+        # Inverse RoPE on output's rope dims (legacy semantics).
+        _apply_rotary_emb(o[..., -rd:], freqs_cis, inverse=True)
+
+        # ----- Grouped output LoRA -----
         o = o.squeeze(0).view(seqlen, self.n_local_groups, -1)  # [S, g, H/g * D]
         wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
         o = torch.einsum("sgd,grd->sgr", o, wo_a)  # [S, g, o_lora_rank]
@@ -1768,6 +2053,7 @@ class Block(nn.Module):
         x: torch.Tensor,
         start_pos: int,
         input_ids: Optional[torch.Tensor],
+        forward_batch: Optional[Any] = None,
     ) -> torch.Tensor:
         # ----- Attention sub-layer with mHC mixing -----
         residual = x
@@ -1775,7 +2061,11 @@ class Block(nn.Module):
             x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
         )
         x = self.attn_norm(x)
-        x = self.attn(x, start_pos)
+        # W4.3-redo (issue sunway513/atom#37): pass the per-step
+        # DSV4ForwardBatch through to Attention. The legacy single-
+        # request path (forward_batch is None or flag off) keeps the
+        # scalar `start_pos` semantics inside `_forward_legacy`.
+        x = self.attn(x, start_pos, forward_batch=forward_batch)
         x = self.hc_post(x, residual, post, comb)
 
         # ----- FFN sub-layer with mHC mixing -----
@@ -1914,7 +2204,11 @@ class MTPBlock(Block):
         self.head: Optional[ParallelHead] = None
 
     def forward(
-        self, x: torch.Tensor, start_pos: int, input_ids: torch.Tensor
+        self,
+        x: torch.Tensor,
+        start_pos: int,
+        input_ids: torch.Tensor,
+        forward_batch: Optional[Any] = None,
     ) -> torch.Tensor:
         """Forward.
 
@@ -1923,6 +2217,9 @@ class MTPBlock(Block):
                 (ATOM 2D-flat convention) or [B, S, hc, D] (legacy 4D).
             start_pos: absolute position offset.
             input_ids: matching token ids.
+            forward_batch: optional ``DSV4ForwardBatch`` (W4.3-redo
+                issue sunway513/atom#37). Threaded through to the
+                inherited Block.forward → Attention.
         Returns:
             Logits of the last token (vocab projected by self.head).
         """
@@ -1936,7 +2233,7 @@ class MTPBlock(Block):
         # adds the hc dim before the trailing D so [num_tokens, D] → [num_tokens, 1, D]
         # broadcasts correctly against x [num_tokens, hc, D]. Same for 4D path.
         x = self.e_proj(e).unsqueeze(-2) + self.h_proj(x)
-        x = super().forward(x, start_pos, input_ids)
+        x = super().forward(x, start_pos, input_ids, forward_batch=forward_batch)
         logits = self.head(
             x, self.hc_head_fn, self.hc_head_scale, self.hc_head_base, self.norm
         )
@@ -1999,6 +2296,7 @@ class DeepseekV4Model(nn.Module):
         self,
         input_ids: torch.Tensor,
         start_pos: int = 0,
+        forward_batch: Optional[Any] = None,
         **model_kwargs: dict,
     ) -> torch.Tensor:
         """Forward.
@@ -2007,22 +2305,32 @@ class DeepseekV4Model(nn.Module):
             input_ids: 1D `[num_tokens]` (ATOM 2D-flat convention) OR 2D
                 `[B, S]` (legacy reference convention; treated as a single
                 sequence of B*S tokens — only correct for B=1).
-            start_pos: absolute position of the first token.
+            start_pos: absolute position of the first token (legacy
+                single-request fallback). Ignored on the W4 path.
+            forward_batch: optional ``DSV4ForwardBatch`` (W4.3-redo
+                issue sunway513/atom#37). When non-None, threaded into
+                each ``Block.forward`` so ``DeepseekV4Attention`` can
+                dispatch into ``_forward_w4`` (per-token RoPE, per-seq
+                slot scatter).
         Returns:
-            Logits of the last token: `[vocab]` (1D path) or `[B, vocab]` (2D path).
+            Logits per sample row: ``[N_sample, vocab]`` for batched
+            requests (one row per active seq) or ``[vocab]``-style legacy
+            output for the single-request path.
         """
         # Normalize input_ids to 1D [num_tokens] for the 2D internal convention.
         if input_ids.dim() == 2:
-            assert (
-                input_ids.size(0) == 1
-            ), "B>1 batched input_ids needs attn_metadata; not supported yet"
+            if forward_batch is None:
+                # Legacy assert: only B=1 supported in the start_pos path.
+                assert (
+                    input_ids.size(0) == 1
+                ), "B>1 batched input_ids needs forward_batch (W4 path)"
             input_ids = input_ids.flatten()
         h = self.embed(input_ids)  # [num_tokens, dim]
         # Expand to hc_mult copies for Hyper-Connections: [num_tokens, hc, dim]
         h = h.unsqueeze(-2).repeat(1, self.hc_mult, 1)
 
         for layer in self.layers:
-            h = layer(h, start_pos, input_ids)
+            h = layer(h, start_pos, input_ids, forward_batch=forward_batch)
 
         # W3.2 (RFC §14 Week 3): slice h to last-token-of-each-sequence
         # using cu_seqlens_q from attn_metadata before the LM head, so a
@@ -2031,17 +2339,21 @@ class DeepseekV4Model(nn.Module):
         # only the trailing row, giving 1 sample for any N — exactly the
         # IndexError@scheduler.py:609 RFC §3.1 #7 evidence chain captured
         # in W3.2-DEBUG (len(prev_token_ids)=1, len(req_ids)=4).
-        try:
-            from atom.utils.forward_context import get_forward_context
+        cu = None
+        if forward_batch is not None:
+            cu = forward_batch.cu_seqlens_q
+        else:
+            try:
+                from atom.utils.forward_context import get_forward_context
 
-            ctx = get_forward_context()
-            attn_meta = getattr(ctx, "attn_metadata", None)
-            cu = getattr(attn_meta, "cu_seqlens_q", None)
-        except Exception:
-            cu = None
+                ctx = get_forward_context()
+                attn_meta = getattr(ctx, "attn_metadata", None)
+                cu = getattr(attn_meta, "cu_seqlens_q", None)
+            except Exception:
+                cu = None
         if cu is not None and cu.numel() >= 2:
             last_token_indices = cu[1:] - 1
-            h = h[last_token_indices]
+            h = h[last_token_indices.to(h.device)]
 
         logits = self.head(
             h, self.hc_head_fn, self.hc_head_scale, self.hc_head_base, self.norm
@@ -2120,8 +2432,40 @@ class DeepseekV4ForCausalLM(nn.Module):
         inputs_embeds: Optional[torch.Tensor] = None,
         **model_kwargs: dict,
     ) -> torch.Tensor:
+        """W4.3-redo (issue sunway513/atom#37): wire DSV4ForwardBatch into
+        the model.
+
+        Three resolution paths:
+
+        1. Caller passes ``forward_batch=...`` in ``model_kwargs``
+           (used by unit tests).
+        2. ``ForwardContext.dsv4_forward_batch`` is populated by
+           ``ModelRunner._maybe_setup_dsv4_forward_batch`` (Task 9).
+           Promote to the W4 path.
+        3. Otherwise: fall back to the legacy ``start_pos`` scalar path
+           (warmup, single-seq eager, PR1 toy validation).
+        """
+        # Path 1: explicit kwarg from a test caller.
+        forward_batch = model_kwargs.pop("forward_batch", None)
+
+        # Path 2: pull from the engine's ForwardContext.
+        if forward_batch is None:
+            try:
+                from atom.utils.forward_context import get_forward_context
+
+                ctx = get_forward_context()
+                forward_batch = getattr(ctx, "dsv4_forward_batch", None)
+            except Exception:
+                forward_batch = None
+
+        # Path 3: legacy scalar start_pos.
         start_pos = int(positions[0].item()) if positions is not None else 0
-        return self.model(input_ids=input_ids, start_pos=start_pos, **model_kwargs)
+        return self.model(
+            input_ids=input_ids,
+            start_pos=start_pos,
+            forward_batch=forward_batch,
+            **model_kwargs,
+        )
 
     def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # In V4, the LM head is fused into DeepseekV4Model.forward (it consumes

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -18,7 +18,7 @@ import math
 import os
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, Iterable, Literal, Optional, Tuple
+from typing import Any, Iterable, List, Literal, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -555,35 +555,29 @@ class Compressor(nn.Module):
         self.norm = _RMSNorm(self.head_dim, args.norm_eps)
 
         # External tensors — assigned by the owning Attention / Indexer at first forward.
+        # Pre-W4.4 the decode-phase state below was held in two
+        # ``register_buffer``s (``kv_state`` / ``score_state``). Under
+        # multi-request concurrent decode that single buffer collided
+        # across requests (every seq overwrote row 0). W4.4-redo (issue
+        # sunway513/atom#37 Tasks 11/12) LIFTS ownership to the engine
+        # ``DSV4KVPool``: when the owning layer runs under a
+        # ``forward_batch`` with a pool, state is rebound to the pool's
+        # per-layer ``kv_state`` / ``score_state`` slabs (zero-copy
+        # ``view_for_layer``). The legacy single-request path lazy-
+        # allocates a layer-local buffer matching the pre-W4.4 shape,
+        # preserving PR1 toy / warmup bit-exactness.
         self.kv_cache: Optional[torch.Tensor] = None
         self.freqs_cis: Optional[torch.Tensor] = None
-
-        # Decode-phase state buffers. With overlap: state[:, :ratio] holds the
-        # overlapping window from the previous compression block; state[:, ratio:]
-        # holds the current in-progress window.
-        self.register_buffer(
-            "kv_state",
-            torch.zeros(
-                args.max_batch_size,
-                coff * compress_ratio,
-                coff * self.head_dim,
-                dtype=torch.float32,
-            ),
-            persistent=False,
-        )
-        self.register_buffer(
-            "score_state",
-            torch.full(
-                (
-                    args.max_batch_size,
-                    coff * compress_ratio,
-                    coff * self.head_dim,
-                ),
-                float("-inf"),
-                dtype=torch.float32,
-            ),
-            persistent=False,
-        )
+        # Plain attributes (NOT register_buffer):
+        #  - ``"kv_state" not in dict(model.named_buffers())``
+        #  - ``"score_state" not in dict(model.named_buffers())``
+        # Verified by tests/test_deepseek_v4_w44_state_redo.py.
+        self.kv_state: Optional[torch.Tensor] = None
+        self.score_state: Optional[torch.Tensor] = None
+        # Cached shapes for the legacy lazy allocator.
+        self._state_max_batch = args.max_batch_size
+        self._state_ring_len = coff * compress_ratio
+        self._state_inner_dim = coff * self.head_dim
 
     def get_kv_cache_spec(
         self,
@@ -628,19 +622,118 @@ class Compressor(nn.Module):
         new_tensor[:, 1:, :ratio] = tensor[:, :-1, :, :d]
         return new_tensor
 
-    def forward(self, x: torch.Tensor, start_pos: int) -> Optional[torch.Tensor]:
+    def _ensure_legacy_state(self, device: torch.device) -> None:
+        """Lazy-allocate the legacy single-request fallback state buffers.
+
+        W4.4-redo (issue sunway513/atom#37 Tasks 11/12): pre-W4.4 these
+        were ``register_buffer``s owned by the Compressor module. With
+        ownership lifted to ``DSV4KVPool``, the legacy single-request
+        path (PR1 toy / warmup) needs a local fallback that matches the
+        pre-W4.4 layout. Allocated on first forward when no pool is
+        available.
+
+        When ``forward_batch.kv_pool`` is provided, ``forward()`` rebinds
+        ``self.kv_state`` / ``self.score_state`` to the pool's per-layer
+        view BEFORE calling this — this method is a no-op on that path.
+        """
+        if self.kv_state is not None and self.score_state is not None:
+            return
+        self.kv_state = torch.zeros(
+            self._state_max_batch,
+            self._state_ring_len,
+            self._state_inner_dim,
+            dtype=torch.float32,
+            device=device,
+        )
+        self.score_state = torch.full(
+            (
+                self._state_max_batch,
+                self._state_ring_len,
+                self._state_inner_dim,
+            ),
+            float("-inf"),
+            dtype=torch.float32,
+            device=device,
+        )
+
+    def _bind_state_from_pool(
+        self, forward_batch: Optional[Any], layer_id: Optional[int]
+    ) -> bool:
+        """W4.4-redo path: rebind state to the pool's per-layer view.
+
+        Returns True iff the pool view was bound (caller is on the W4
+        multi-request path); False iff the legacy path applies.
+        """
+        if (
+            forward_batch is None
+            or getattr(forward_batch, "kv_pool", None) is None
+            or layer_id is None
+        ):
+            return False
+        view = forward_batch.kv_pool.view_for_layer(layer_id)
+        kv_state_view = view.get("kv_state")
+        score_state_view = view.get("score_state")
+        if kv_state_view is None or score_state_view is None:
+            return False
+        self.kv_state = kv_state_view
+        self.score_state = score_state_view
+        return True
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        start_pos: int = 0,
+        forward_batch: Optional[Any] = None,
+        layer_id: Optional[int] = None,
+    ) -> Optional[torch.Tensor]:
         """Compress KV for the input tokens. Writes into self.kv_cache when a
         compression block boundary is hit; otherwise just buffers state and returns None.
+
+        Two operating modes (W4.4-redo — issue sunway513/atom#37 Tasks 11/12):
+
+        - **W4 multi-request path** (``forward_batch`` carries a
+          ``DSV4KVPool``): per-token state writes via per-token slot/row
+          indexing into the pool's ``kv_state`` / ``score_state`` slab;
+          per-seq compress-boundary check ``(positions[t] + 1) % ratio
+          == 0`` (mirrors SGLang ``compressor.py:236``'s stateless ring-
+          slot math). Compressed entries land in ``kv_cache[slot, p_last
+          // ratio]`` so two seqs cannot share a write target.
+        - **Legacy single-request path** (``forward_batch`` is None):
+          identical to the pre-W4.4 ``forward(x, start_pos)`` semantics
+          using lazy-allocated local state buffers. Preserves PR1 toy /
+          warmup / single-seq-eager bit-exactness.
 
         Args:
             x: [num_tokens, dim] (2D, ATOM convention) or [B, S, dim] (3D, legacy).
                 2D input is treated as a single sequence (B=1 implicit).
             start_pos: starting position in the absolute sequence (0 = prefill).
+                Ignored when ``forward_batch`` drives the W4 path.
+            forward_batch: optional ``DSV4ForwardBatch`` enabling the W4
+                multi-request path with pool-owned state.
+            layer_id: optional global layer id used to fetch the pool's
+                per-layer state view. Required iff
+                ``forward_batch.kv_pool`` is not None.
         Returns:
             Compressed KV slice that was just written ([1, S/ratio, head_dim] in
             prefill, or [1, 1, head_dim] in decode), or None if no compression
             boundary was hit on this call.
         """
+        # W4.4-redo: bind state to the pool view (or fall back to legacy local).
+        bound_pool = self._bind_state_from_pool(forward_batch, layer_id)
+        if not bound_pool:
+            self._ensure_legacy_state(x.device)
+
+        # On the W4 path, dispatch to the dedicated per-token write
+        # branch. ``self.kv_cache`` is bound by the owning module
+        # (Indexer / Attention) BEFORE this call.
+        if (
+            forward_batch is not None
+            and getattr(forward_batch, "kv_pool", None) is not None
+            and bound_pool
+            and self.kv_cache is not None
+        ):
+            return self._forward_w4(x, forward_batch, layer_id)
+
         assert self.kv_cache is not None, "compressor.kv_cache must be set by owner"
         assert self.freqs_cis is not None, "compressor.freqs_cis must be set by owner"
         if x.dim() == 2:
@@ -772,6 +865,150 @@ class Compressor(nn.Module):
             self.kv_cache[:batch_decode, start_pos // ratio] = kv.squeeze(1)
         return kv
 
+    def _forward_w4(
+        self,
+        x: torch.Tensor,
+        forward_batch: Any,
+        layer_id: int,
+    ) -> Optional[torch.Tensor]:
+        """W4.4-redo multi-request Compressor forward (issue sunway513/atom#37 Tasks 11/12).
+
+        Implements per-token state scatter into the engine pool's
+        ``kv_state`` / ``score_state`` slabs and per-seq compress-boundary
+        emission. Mirrors SGLang ``compressor.py:236``'s ring-slot math:
+        each token writes to its OWN seq's slot row, the compress trigger
+        is checked per-seq using the seq's last-token absolute position,
+        and the compressed result lands in ``kv_cache[slot, p_last //
+        ratio]`` so two seqs can never share a write target.
+
+        Returns the compressed slice (per-seq packed in slot order) if
+        any seq triggered compression on this step, otherwise ``None``.
+        Per-seq concatenation with the window KV at the attention layer
+        is silicon territory; this method only owns state writes and
+        the per-seq compressed-cache scatter.
+        """
+        assert self.kv_state is not None and self.score_state is not None
+        assert self.freqs_cis is not None, "compressor.freqs_cis must be set by owner"
+
+        if x.dim() == 2:
+            # [num_tokens, dim] is the W4 packed-batch ATOM convention.
+            x_flat = x
+        else:
+            # Legacy 3D arrival — flatten the implicit batch dim.
+            x_flat = x.reshape(-1, x.size(-1))
+
+        ratio = self.compress_ratio
+        overlap = self.overlap
+        d = self.head_dim
+        rd = self.rope_head_dim
+        dtype = x.dtype if x.dim() == 2 else x.flatten(0, 1).dtype
+
+        # All compressor math runs in fp32 for stability (matches legacy).
+        x_f32 = x_flat.float()
+        kv = self.wkv(x_f32)  # [num_tokens, coff*d]
+        score = self.wgate(x_f32)  # [num_tokens, coff*d]
+
+        device = x.device
+        positions = forward_batch.positions.to(device=device, dtype=torch.long)
+        cu = forward_batch.cu_seqlens_q.to(device=device, dtype=torch.long)
+        slot_indices = forward_batch.req_pool_indices.to(
+            device=device, dtype=torch.long
+        )
+        num_tokens = positions.numel()
+        if num_tokens == 0:
+            return None
+
+        # Per-token slot lookup (same bucketize used by compute_out_cache_loc).
+        token_idx = torch.arange(num_tokens, dtype=torch.long, device=device)
+        seg_id = torch.bucketize(token_idx, cu[1:], right=True)
+        slot_per_token = slot_indices[seg_id]  # [num_tokens]
+
+        # Add APE per-token (legacy decode adds ape[start_pos % ratio] per
+        # decode step; W4 generalizes to per-token absolute position).
+        score_with_ape = score + self.ape[positions % ratio]
+
+        # Per-token state row index. In overlap mode every "live" token
+        # writes into the current half at offset ``ratio + (pos % ratio)``.
+        # The previous-window half is rolled at compress-boundary triggers
+        # below. In non-overlap mode tokens go straight to ``pos % ratio``.
+        if overlap:
+            row_in_state = ratio + (positions % ratio)
+        else:
+            row_in_state = positions % ratio
+
+        # Per-token scatter via 2D advanced indexing into kv_state /
+        # score_state. (slot_per_token, row_in_state) is a paired index;
+        # PyTorch broadcasts these into a single advanced-index gather/put.
+        self.kv_state[slot_per_token, row_in_state] = kv.to(self.kv_state.dtype)
+        self.score_state[slot_per_token, row_in_state] = score_with_ape.to(
+            self.score_state.dtype
+        )
+
+        # Per-seq compress-boundary: a seq triggers iff its LAST token in
+        # this batch satisfies ``(pos + 1) % ratio == 0``. cu_seqlens_q
+        # gives us each seq's last-token index in the packed buffer.
+        num_seqs = cu.numel() - 1
+        if num_seqs == 0:
+            return None
+        last_token_idx = cu[1:] - 1  # [num_seqs]
+        last_positions = positions[last_token_idx]  # [num_seqs]
+        compress_mask = (last_positions + 1) % ratio == 0  # [num_seqs] bool
+        compress_seqs = compress_mask.nonzero(as_tuple=False).flatten()
+        if compress_seqs.numel() == 0:
+            return None
+
+        compressed_outputs: List[torch.Tensor] = []
+        for s_idx in compress_seqs.tolist():
+            slot = int(slot_indices[s_idx].item())
+            p_last = int(last_positions[s_idx].item())
+            if overlap:
+                state_slot = self.kv_state[slot]  # [ring_len, inner]
+                score_slot = self.score_state[slot]
+                kv_state_concat = torch.cat(
+                    [state_slot[:ratio, :d], state_slot[ratio:, d:]], dim=0
+                )
+                score_state_concat = torch.cat(
+                    [score_slot[:ratio, :d], score_slot[ratio:, d:]], dim=0
+                )
+                kv_seq = (kv_state_concat * score_state_concat.softmax(dim=0)).sum(
+                    dim=0, keepdim=True
+                )  # [1, d]
+                # Roll: just-completed window becomes the next overlap.
+                self.kv_state[slot, :ratio] = state_slot[ratio:]
+                self.score_state[slot, :ratio] = score_slot[ratio:]
+            else:
+                state_slot = self.kv_state[slot]
+                score_slot = self.score_state[slot]
+                kv_seq = (state_slot * score_slot.softmax(dim=0)).sum(
+                    dim=0, keepdim=True
+                )  # [1, inner]
+
+            # Norm + RoPE + QAT round-trip (matches the legacy decode emit).
+            kv_seq = self.norm(kv_seq.to(dtype))
+            freqs = self.freqs_cis[p_last + 1 - ratio].unsqueeze(0)
+            _apply_rotary_emb(kv_seq[..., -rd:], freqs)
+            if self.rotate:
+                kv_seq = rotate_activation(kv_seq)
+                fp4_act_quant_inplace(kv_seq, _FP4_BLOCK_SIZE)
+            else:
+                act_quant_inplace(kv_seq[..., :-rd], 64, self.scale_fmt)
+
+            # Per-seq compressed write target: kv_cache[slot, p_last // ratio].
+            # ``self.kv_cache`` is bound by the owning Indexer/Attention to
+            # the appropriate pool view (``indexer_kv`` for the Indexer's
+            # inner compressor; layer-local fallback for a plain Compressor).
+            assert self.kv_cache is not None
+            self.kv_cache[slot, p_last // ratio] = kv_seq.squeeze(0).to(
+                self.kv_cache.dtype
+            )
+            compressed_outputs.append(kv_seq)
+
+        if not compressed_outputs:
+            return None
+        # Stack per-seq emissions in slot order for callers that want to
+        # consume them downstream. Shape: [num_emit, 1, head_dim].
+        return torch.stack(compressed_outputs, dim=0)
+
 
 class Indexer(nn.Module):
     """Selects top-k compressed KV positions for sparse attention via learned scoring.
@@ -824,15 +1061,22 @@ class Indexer(nn.Module):
             rotate=True,
             prefix=f"{prefix}.compressor",
         )
-        self.register_buffer(
-            "kv_cache",
-            torch.zeros(
-                args.max_batch_size,
-                args.max_seq_len // compress_ratio,
-                self.head_dim,
-            ),
-            persistent=False,
-        )
+        # ----- KV cache lifetime — W4.4-redo (issue sunway513/atom#37 Tasks 11/12) -----
+        # Pre-W4.4 this was a ``register_buffer("kv_cache", ...)`` owned
+        # by the Indexer. Under multi-request decode that single buffer
+        # collided across requests (every seq overwrote slot 0). W4.4-redo
+        # lifts ownership to the engine ``DSV4KVPool``: when the model
+        # runs under a ``forward_batch`` with a pool, the layer rebinds
+        # ``self.kv_cache`` to the pool's per-layer ``indexer_kv`` view
+        # at every forward (zero-copy slice). The legacy single-request
+        # path lazy-allocates a layer-local buffer matching the pre-W4.4
+        # shape. Plain attribute (NOT register_buffer):
+        #   - ``"kv_cache" not in dict(model.named_buffers())``
+        #   - W4 multi-request path uses the pool view
+        #   - Legacy / warmup path uses the lazy local fallback
+        self.kv_cache: Optional[torch.Tensor] = None
+        self._kv_cache_legacy_max_batch = args.max_batch_size
+        self._kv_cache_legacy_len = args.max_seq_len // compress_ratio
         self.freqs_cis: Optional[torch.Tensor] = None
 
     def get_kv_cache_spec(
@@ -857,14 +1101,60 @@ class Indexer(nn.Module):
             compress_ratio=self.compress_ratio,
         )
 
+    def _ensure_legacy_kv_cache(self, device: torch.device, dtype: torch.dtype) -> None:
+        """Lazy-allocate the legacy single-request fallback ``kv_cache``.
+
+        W4.4-redo (issue sunway513/atom#37 Tasks 11/12): when running
+        without an engine pool we need a layer-local buffer matching
+        the pre-W4.4 ``register_buffer`` layout. Allocate on first
+        forward when ``self.kv_cache is None``. On the W4 path the
+        per-layer pool view is bound BEFORE this method runs, so it's
+        a no-op.
+        """
+        if self.kv_cache is not None:
+            return
+        self.kv_cache = torch.zeros(
+            self._kv_cache_legacy_max_batch,
+            self._kv_cache_legacy_len,
+            self.head_dim,
+            device=device,
+            dtype=dtype,
+        )
+
+    def _bind_kv_cache_from_pool(
+        self, forward_batch: Optional[Any], layer_id: Optional[int]
+    ) -> bool:
+        """W4.4-redo path: rebind ``self.kv_cache`` to the pool's indexer view."""
+        if (
+            forward_batch is None
+            or getattr(forward_batch, "kv_pool", None) is None
+            or layer_id is None
+        ):
+            return False
+        view = forward_batch.kv_pool.view_for_layer(layer_id)
+        indexer_view = view.get("indexer_kv")
+        if indexer_view is None:
+            return False
+        self.kv_cache = indexer_view
+        return True
+
     def forward(
         self,
         x: torch.Tensor,
         qr: torch.Tensor,
         start_pos: int,
         offset: int,
+        forward_batch: Optional[Any] = None,
+        layer_id: Optional[int] = None,
     ) -> torch.Tensor:
         """Compute sparse top-k indices over the indexer's compressed KV cache.
+
+        W4.4-redo (issue sunway513/atom#37 Tasks 11/12): when
+        ``forward_batch`` carries an engine ``DSV4KVPool``,
+        ``self.kv_cache`` is rebound to the pool's per-layer indexer
+        view (zero-copy) and the inner Compressor consumes the pool's
+        compressor state slab via per-token writes. The legacy single-
+        request path keeps the lazy-allocated layer-local buffer.
 
         Args:
             x: [num_tokens, dim] input hidden states (for compressor + weights_proj).
@@ -872,6 +1162,8 @@ class Indexer(nn.Module):
             start_pos: absolute sequence start position.
             offset: offset added to returned indices to land them in the
                 concatenated (window || compressed) KV layout consumed by sparse_attn.
+            forward_batch: optional ``DSV4ForwardBatch`` for the W4 path.
+            layer_id: global layer id (required iff ``forward_batch`` has a pool).
         Returns:
             topk_idxs: [1, num_tokens, K] int (B=1 implicit). -1 = future-masked.
         """
@@ -883,9 +1175,19 @@ class Indexer(nn.Module):
         rd = self.rope_head_dim
         end_pos = start_pos + seqlen
 
-        # Lazy plumb the indexer's kv_cache + freqs_cis into its compressor.
-        if self.compressor.kv_cache is None:
+        # W4.4-redo: rebind kv_cache to the pool view if available; else
+        # ensure legacy local buffer is allocated.
+        bound_pool = self._bind_kv_cache_from_pool(forward_batch, layer_id)
+        if not bound_pool:
+            self._ensure_legacy_kv_cache(x.device, x.dtype)
+
+        # Plumb the inner compressor's kv_cache (write target) and
+        # freqs_cis. On the W4 path the inner compressor's W4 forward
+        # uses ``self.kv_cache`` already bound to the pool's indexer
+        # view, so we propagate that binding here too.
+        if self.compressor.kv_cache is None or bound_pool:
             self.compressor.kv_cache = self.kv_cache
+        if self.compressor.freqs_cis is None:
             self.compressor.freqs_cis = self.freqs_cis
 
         # ----- Indexer Q (2D Linear, then add B=1 dim for RoPE / einsum) -----
@@ -896,7 +1198,15 @@ class Indexer(nn.Module):
         fp4_act_quant_inplace(q, _FP4_BLOCK_SIZE)
 
         # ----- Indexer KV (Compressor takes 2D, mutates kv_cache) -----
-        self.compressor(x, start_pos)
+        # On the W4 path the inner Compressor consumes forward_batch +
+        # layer_id directly, performing per-token state writes through
+        # the pool views. Legacy path keeps the (x, start_pos) signature.
+        if bound_pool:
+            self.compressor(
+                x, start_pos=start_pos, forward_batch=forward_batch, layer_id=layer_id
+            )
+        else:
+            self.compressor(x, start_pos)
         # weights_proj is ATOM Linear → 2D input; restore B=1 dim for einsum.
         weights = (
             self.weights_proj(x) * (self.softmax_scale * self.n_heads**-0.5)
@@ -1246,15 +1556,25 @@ class DeepseekV4Attention(nn.Module):
         # forward (seqlen=MAX_BATCHED_TOKENS with zeros) fills these buffers
         # with garbage. Real prefill only overwrites a few slots, leaving
         # stale warmup data that poisons decode attention.
+        # W4.4-redo: Compressor state and Indexer kv_cache are now plain
+        # attributes lazy-allocated by ``_ensure_legacy_state`` /
+        # ``_ensure_legacy_kv_cache`` on the first compressor/indexer
+        # call. Guard the reset on ``is not None`` for the very first
+        # forward where they haven't been allocated yet.
         if start_pos == 0:
             self.kv_cache.zero_()
             if self.compress_ratio:
-                self.compressor.kv_state.zero_()
-                self.compressor.score_state.fill_(float("-inf"))
+                if self.compressor.kv_state is not None:
+                    self.compressor.kv_state.zero_()
+                if self.compressor.score_state is not None:
+                    self.compressor.score_state.fill_(float("-inf"))
                 if self.indexer is not None:
-                    self.indexer.kv_cache.zero_()
-                    self.indexer.compressor.kv_state.zero_()
-                    self.indexer.compressor.score_state.fill_(float("-inf"))
+                    if self.indexer.kv_cache is not None:
+                        self.indexer.kv_cache.zero_()
+                    if self.indexer.compressor.kv_state is not None:
+                        self.indexer.compressor.kv_state.zero_()
+                    if self.indexer.compressor.score_state is not None:
+                        self.indexer.compressor.score_state.fill_(float("-inf"))
 
         # ----- Q: low-rank projection + per-head RMSNorm + partial RoPE -----
         # ATOM TP linears require 2D inputs; subsequent ops (RoPE, sparse_attn)
@@ -1399,11 +1719,12 @@ class DeepseekV4Attention(nn.Module):
         eliminating the row-0 collision class of bugs documented in
         W3.2 v3..v6.1.
 
-        Compressor / Indexer state remains ``register_buffer``-owned in
-        Task 10 (lifted to the pool by Tasks 11/12). The W4 path here
-        skips compressor/indexer activations and uses window-only
-        topk_idxs. Compressed-attention multi-request prefill is
-        explicitly out of scope until Tasks 11/12.
+        Compressor / Indexer state has been migrated to the engine pool
+        in Tasks 11/12 (W4.4-redo). For HCA-only layers (compress_ratio
+        >= 8 with no Indexer) the standalone Compressor's per-token
+        state writes happen here via ``forward_batch + layer_id``. For
+        C4 layers (Indexer present) the Indexer wraps the inner
+        Compressor and is invoked during topk build.
 
         Args:
             x: ``[num_tokens, dim]`` flat ATOM convention.
@@ -1423,12 +1744,22 @@ class DeepseekV4Attention(nn.Module):
 
         positions = forward_batch.positions  # [num_tokens] long
         rd = self.rope_head_dim
+        win = self.window_size
+        ratio = self.compress_ratio
 
         # Per-layer pool view: [num_active_seqs, ring_main, head_dim].
         # Zero-copy slice; rebound every step.
         pool_view = forward_batch.kv_pool.view_for_layer(self.layer_id)
         kv_cache_view = pool_view["kv_cache"]
         n_slots, ring_main, head_dim = kv_cache_view.shape
+
+        # W4.4-redo: plumb freqs_cis to the compressor/indexer (state
+        # is engine-pool-owned; only freqs_cis still flows from here).
+        if self.compress_ratio:
+            if self.compressor is not None and self.compressor.freqs_cis is None:
+                self.compressor.freqs_cis = self.freqs_cis
+            if self.indexer is not None and self.indexer.freqs_cis is None:
+                self.indexer.freqs_cis = self.freqs_cis
 
         # ---- Per-token RoPE (CRITICAL — was the W3.2-v5 wall) ----
         # Gather one row per token by absolute position. Under
@@ -1474,6 +1805,43 @@ class DeepseekV4Attention(nn.Module):
 
         # ---- Per-token window topk_idxs ----
         topk_idxs = self._build_topk_per_token(forward_batch)  # [1, T, win] int64
+
+        # W4.4-redo (Tasks 11/12): drive Compressor / Indexer per-token
+        # state writes through the pool. For C4 layers the Indexer
+        # wraps the inner Compressor and emits its compress topk_idxs;
+        # for HCA-only layers we drive the standalone Compressor's
+        # state writes here and use the helper-built compress topk.
+        if self.compress_ratio:
+            offset = win
+            # Use first token's position as the legacy-compatible
+            # start_pos for the Indexer's mask construction; the W4
+            # path's per-seq state writes are driven by
+            # forward_batch.positions internally.
+            sp = int(positions[0].item()) if positions.numel() > 0 else 0
+            if self.indexer is not None:
+                compress_topk_idxs = self.indexer(
+                    x,
+                    qr,
+                    sp,
+                    offset,
+                    forward_batch=forward_batch,
+                    layer_id=self.layer_id,
+                )
+            else:
+                # Standalone Compressor (HCA-only). Drive its per-token
+                # state writes via the W4 path, then build the compress
+                # topk via the legacy helper (the helper only needs
+                # ratio + start_pos to enumerate compressed positions).
+                self.compressor(
+                    x,
+                    forward_batch=forward_batch,
+                    layer_id=self.layer_id,
+                )
+                compress_topk_idxs = _get_compress_topk_idxs(
+                    ratio, 1, seqlen, sp, offset, device=x.device
+                )
+            topk_idxs = torch.cat([topk_idxs, compress_topk_idxs], dim=-1)
+
         topk_idxs = topk_idxs.int()
 
         # ---- Build per-token KV slabs: each token attends to its OWN

--- a/atom/utils/dsv4_guard.py
+++ b/atom/utils/dsv4_guard.py
@@ -35,12 +35,16 @@ def validate_dsv4_multireq(architectures: list[str], max_num_seqs: int) -> None:
     engine-owned KV pools, branch `feat/dsv4-forward-batch-paged-kv`).
 
     Until W4 lands, refuse multi-request configs to prevent silently-
-    broken output. The `ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1` env override
-    exists for kernel-level perf experiments where output correctness
-    is not being measured.
+    broken output. Bypass requires **double opt-in** (W4.3 amendment,
+    PR #46 P1.1 review fix): BOTH `ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1`
+    AND `ATOM_DSV4_USE_W4_PATH=1` must be set together. Either alone
+    rejects, because `UNSAFE_MULTIREQ_DEV=1` without the W4 path opt-in
+    would route through the legacy (broken) multi-request path that
+    crashed PR #42 with HSA exception 0x1016.
 
     Raises:
-        ValueError: when DSV4 + max_num_seqs > 1 + override unset.
+        ValueError: when DSV4 + max_num_seqs > 1 + double opt-in
+            unsatisfied (either flag missing).
     """
     if not is_dsv4_arch(architectures):
         return
@@ -48,15 +52,24 @@ def validate_dsv4_multireq(architectures: list[str], max_num_seqs: int) -> None:
         return
     from atom.utils import envs
 
-    if envs.ATOM_DSV4_UNSAFE_MULTIREQ_DEV:
-        return
-    raise ValueError(
-        "DSV4 architectures currently support only "
-        f"max_num_seqs=1 (got max_num_seqs={max_num_seqs}). "
-        "Multi-request support is in development on the W4 branch "
-        "(feat/dsv4-forward-batch-paged-kv); see "
-        "https://github.com/sunway513/ATOM/issues/37 for context. "
-        "To bypass this guard for kernel-level perf experiments "
-        "where output correctness is NOT being measured, set "
-        "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1."
-    )
+    unsafe = envs.ATOM_DSV4_UNSAFE_MULTIREQ_DEV
+    use_w4 = envs.ATOM_DSV4_USE_W4_PATH
+
+    if not unsafe:
+        raise ValueError(
+            "DSV4 architectures currently support only "
+            f"max_num_seqs=1 (got max_num_seqs={max_num_seqs}). "
+            "Multi-request support is in development on the W4 branch; "
+            "see https://github.com/sunway513/ATOM/issues/37. To bypass "
+            "this guard for kernel-level perf experiments where output "
+            "correctness is NOT being measured, set BOTH "
+            "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1 AND ATOM_DSV4_USE_W4_PATH=1."
+        )
+    if not use_w4:
+        raise ValueError(
+            "DSV4 multi-request requires ATOM_DSV4_USE_W4_PATH=1 to opt "
+            "into the W4 path. ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1 alone "
+            "would route through the legacy (broken) multi-request "
+            "path. See issue #37."
+        )
+    # Both flags set → allow

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -105,6 +105,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": lambda: (
         os.getenv("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", "0") == "1"
     ),
+    # --- DSV4 W4.3-redo flags (issue #37) ---
+    # Enable the W4 multi-request path. When 0 (default), DSV4 single-request
+    # legacy path runs unchanged. Task 7 amends the Path 2 guard to require
+    # this flag together with ATOM_DSV4_UNSAFE_MULTIREQ_DEV before allowing
+    # max_num_seqs > 1.
+    "ATOM_DSV4_USE_W4_PATH": lambda: (os.getenv("ATOM_DSV4_USE_W4_PATH", "0") == "1"),
+    # Enable host-side AITER ABI validator before each sparse_attn call.
+    # Zero prod overhead when off.
+    "ATOM_AITER_VALIDATE": lambda: (os.getenv("ATOM_AITER_VALIDATE", "0") == "1"),
 }
 
 

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -329,6 +329,16 @@ class ForwardContext:
 
     ubatch_slices: Optional[list[Any]] = None
 
+    # W4.3-redo (issue #37 P2.2): the per-step DSV4 KV pool + ForwardBatch.
+    # Both fields stay ``None`` for non-DSV4 models, for DSV4 in legacy single-
+    # request fallback, and for the warmup ``is_dummy_run`` path. Models read
+    # ``dsv4_forward_batch`` to dispatch into the W4 multi-request kernel chain
+    # and ``dsv4_pool`` if they need direct slot lookups (typed as ``Any`` to
+    # avoid a circular import on ``DSV4KVPool`` / ``DSV4ForwardBatch``).
+    dsv4_pool: Optional[Any] = None
+
+    dsv4_forward_batch: Optional[Any] = None
+
     def __post_init__(self):
         if not hasattr(self, "no_compile_layers") or self.no_compile_layers is None:
             self.no_compile_layers = {}
@@ -366,6 +376,8 @@ def set_forward_context(
     num_tokens_across_dp: Optional[torch.Tensor] = None,
     spec_decode_metadata: Optional[SpecDecodeMetadata] = None,
     ubatch_slices: Optional[list[Any]] = None,
+    dsv4_pool: Optional[Any] = None,
+    dsv4_forward_batch: Optional[Any] = None,
 ) -> None:
     global _forward_context
     dp_metadata: Optional[DPMetadata] = None
@@ -385,6 +397,8 @@ def set_forward_context(
         dp_metadata=dp_metadata,
         spec_decode_metadata=spec_decode_metadata,
         ubatch_slices=ubatch_slices,
+        dsv4_pool=dsv4_pool,
+        dsv4_forward_batch=dsv4_forward_batch,
     )  # _forward_context.attn_metadata = attn_metadata
     # _forward_context.no_compile_layers = atom_config.compilation_config.static_forward_context
     # _forward_context = ForwardContext(no_compile_layers=atom_config.compilation_config.static_forward_context, attn_metadata=attn_metadata)

--- a/tests/test_deepseek_v4_w43_redo.py
+++ b/tests/test_deepseek_v4_w43_redo.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""W4.3-redo: DeepseekV4Attention consumes DSV4ForwardBatch + KVPool (issue sunway513/atom#37).
+
+Validates spec §3 'ATOM W4.3-redo (main attention)' component:
+
+- ``DeepseekV4Attention.forward`` accepts an optional ``forward_batch``
+  kwarg.
+- ``ATOM_DSV4_USE_W4_PATH=1`` + non-None ``forward_batch`` enters the
+  per-token RoPE / per-seq slot KV scatter path (``_forward_w4``).
+- ``ATOM_DSV4_USE_W4_PATH=0`` (or ``forward_batch is None``) keeps the
+  legacy single-request register_buffer path (``_forward_legacy``,
+  bit-for-bit preserved post-#44).
+- ``_forward_w4`` calls the AITER metadata validator
+  (``dsv4_validate_sparse_attn_metadata``) immediately before
+  ``sparse_attn`` when ``ATOM_AITER_VALIDATE=1``.
+- ``_forward_w4`` uses per-token RoPE indexing
+  (``freqs_cis[positions]``) rather than the legacy
+  ``freqs_cis[start_pos:start_pos+seqlen]`` contiguous slice (the
+  W3.2 v3..v6.1 bug class).
+- ``register_buffer("kv_cache", ...)`` is preserved in ``__init__`` for
+  the legacy fallback (deliberate, per Task 10 spec §10.6).
+
+We use AST-level inspection so the test runs on CPU without HF
+download or GPU. ``DeepseekV4ForCausalLM`` instantiation pulls in
+aiter ROCm kernels that the unit-test image's stubbed ``aiter``
+cannot satisfy. The full forward smoke run is silicon-validation
+territory (Task 14).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# AST helpers — read the source without importing the module
+# ---------------------------------------------------------------------------
+
+ATOM_ROOT = Path(__file__).resolve().parent.parent
+DSV4_SOURCE = ATOM_ROOT / "atom" / "models" / "deepseek_v4.py"
+
+
+def _tree() -> ast.Module:
+    return ast.parse(DSV4_SOURCE.read_text())
+
+
+def _find_class(tree: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name!r} not found in deepseek_v4.py")
+
+
+def _find_method(cls: ast.ClassDef, name: str):
+    for n in cls.body:
+        if isinstance(n, ast.FunctionDef) and n.name == name:
+            return n
+    return None
+
+
+def _method_src(cls: ast.ClassDef, name: str) -> str:
+    m = _find_method(cls, name)
+    if m is None:
+        return ""
+    return ast.unparse(m)
+
+
+def _method_params(cls: ast.ClassDef, name: str) -> list[str]:
+    m = _find_method(cls, name)
+    if m is None:
+        return []
+    args = m.args
+    out: list[str] = [a.arg for a in args.args]
+    out += [a.arg for a in args.kwonlyargs]
+    if args.vararg is not None:
+        out.append("*" + args.vararg.arg)
+    if args.kwarg is not None:
+        out.append("**" + args.kwarg.arg)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestForwardSignature:
+    def test_forward_accepts_forward_batch_kwarg(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        params = _method_params(cls, "forward")
+        assert "forward_batch" in params, (
+            "DeepseekV4Attention.forward must accept a forward_batch kwarg; "
+            f"got params {params}"
+        )
+
+    def test_block_forward_accepts_forward_batch_kwarg(self):
+        cls = _find_class(_tree(), "Block")
+        params = _method_params(cls, "forward")
+        assert (
+            "forward_batch" in params
+        ), f"Block.forward must accept a forward_batch kwarg; got params {params}"
+
+    def test_model_forward_accepts_forward_batch_kwarg(self):
+        cls = _find_class(_tree(), "DeepseekV4Model")
+        params = _method_params(cls, "forward")
+        # Either named arg or **kwargs that the body propagates.
+        has_forward_batch = "forward_batch" in params
+        # Inspect body for a forward_batch=... pull-through if not named.
+        src = _method_src(cls, "forward")
+        propagates_to_layer = "forward_batch=forward_batch" in src
+        assert has_forward_batch or propagates_to_layer, (
+            "DeepseekV4Model.forward must accept and propagate forward_batch; "
+            f"params={params}"
+        )
+
+
+class TestDispatch:
+    def test_attention_has_legacy_method(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        assert (
+            _find_method(cls, "_forward_legacy") is not None
+        ), "DeepseekV4Attention must expose _forward_legacy"
+
+    def test_attention_has_w4_method(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        assert (
+            _find_method(cls, "_forward_w4") is not None
+        ), "DeepseekV4Attention must expose _forward_w4"
+
+    def test_forward_dispatches_on_flag_and_forward_batch(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "forward")
+        # Flag check
+        assert (
+            "ATOM_DSV4_USE_W4_PATH" in src
+        ), "forward() must consult ATOM_DSV4_USE_W4_PATH to dispatch to W4 path"
+        # Both branches dispatched
+        assert "_forward_legacy" in src, "forward() must dispatch to _forward_legacy"
+        assert "_forward_w4" in src, "forward() must dispatch to _forward_w4"
+
+
+class TestPerTokenRoPE:
+    def test_w4_path_uses_per_token_rope(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        assert src, "_forward_w4 must exist"
+        per_token_markers = (
+            "freqs_cis[positions]",
+            "freqs_cis[forward_batch.positions]",
+        )
+        assert any(m in src for m in per_token_markers), (
+            "_forward_w4 must use per-token RoPE indexing "
+            "(freqs_cis[positions] or freqs_cis[forward_batch.positions])"
+        )
+
+    def test_w4_path_does_not_use_legacy_contiguous_slice(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        # any of these patterns indicates the legacy single-start_pos slice
+        forbidden = (
+            "start_pos : start_pos + seqlen",
+            "start_pos:start_pos + seqlen",
+            "start_pos:start_pos+seqlen",
+        )
+        for f in forbidden:
+            assert f not in src, (
+                "_forward_w4 must not use the legacy contiguous freqs_cis slice "
+                f"(found {f!r})"
+            )
+
+
+class TestKVScatter:
+    def test_w4_path_uses_compute_out_cache_loc(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        assert (
+            "compute_out_cache_loc" in src or "out_cache_loc" in src
+        ), "_forward_w4 must compute or use the per-token out_cache_loc"
+
+    def test_w4_path_uses_pool_view_for_layer(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        assert "view_for_layer" in src or "kv_pool" in src, (
+            "_forward_w4 must consume forward_batch.kv_pool / view_for_layer "
+            "instead of the legacy register_buffer kv_cache"
+        )
+
+
+class TestValidatorIntegration:
+    def test_w4_path_calls_validator(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        assert (
+            "dsv4_validate_sparse_attn_metadata" in src
+        ), "_forward_w4 must call dsv4_validate_sparse_attn_metadata"
+        assert (
+            "ATOM_AITER_VALIDATE" in src
+        ), "_forward_w4 must gate the validator on ATOM_AITER_VALIDATE"
+
+    def test_validator_called_before_sparse_attn(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_w4")
+        i_validator = src.find("dsv4_validate_sparse_attn_metadata")
+        i_sparse_attn = src.find("sparse_attn(")
+        assert i_validator != -1, "validator missing"
+        assert i_sparse_attn != -1, "sparse_attn call missing"
+        assert i_validator < i_sparse_attn, (
+            "Validator must be invoked before sparse_attn so OOB indices "
+            "fail with a host-side ValueError, not a GPU HSA crash"
+        )
+
+
+class TestPerTokenTopkHelper:
+    def test_helper_method_or_function_exists(self):
+        tree = _tree()
+        # method on the class
+        cls = _find_class(tree, "DeepseekV4Attention")
+        has_method = _find_method(cls, "_build_topk_per_token") is not None
+        # or module-level function
+        has_module_helper = False
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef) and node.name in (
+                "_build_topk_per_token",
+                "_get_window_topk_idxs_pertoken",
+            ):
+                has_module_helper = True
+                break
+        assert (
+            has_method or has_module_helper
+        ), "Per-token topk helper (method or module-level fn) must exist"
+
+
+class TestLegacyPreserved:
+    def test_legacy_method_signature(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        params = _method_params(cls, "_forward_legacy")
+        # _forward_legacy(self, x[, start_pos]) — must take x positionally.
+        assert (
+            "x" in params and len(params) >= 2
+        ), f"_forward_legacy must take self,x[,start_pos]; got {params}"
+
+    def test_legacy_path_body_preserves_register_buffer_kv_cache(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "_forward_legacy")
+        assert (
+            "self.kv_cache" in src
+        ), "_forward_legacy must keep self.kv_cache (the register_buffer)"
+
+    def test_attention_init_keeps_register_buffer(self):
+        cls = _find_class(_tree(), "DeepseekV4Attention")
+        src = _method_src(cls, "__init__")
+        # ast.unparse normalizes string quotes to single quotes, so accept
+        # either single- or double-quoted "kv_cache" literal.
+        kv_cache_literal = ("'kv_cache'" in src) or ('"kv_cache"' in src)
+        assert "register_buffer(" in src and kv_cache_literal, (
+            "DeepseekV4Attention.__init__ must keep " 'register_buffer("kv_cache", ...)'
+        )
+
+
+class TestForCausalLMForwardBatchPlumbing:
+    def test_for_causal_lm_pulls_forward_batch_from_context(self):
+        cls = _find_class(_tree(), "DeepseekV4ForCausalLM")
+        src = _method_src(cls, "forward")
+        assert (
+            "dsv4_forward_batch" in src or "forward_batch" in src
+        ), "DeepseekV4ForCausalLM.forward must wire forward_batch from ForwardContext"
+
+
+class TestBlockForwardThreadsForwardBatch:
+    def test_block_forward_threads_forward_batch_into_attn(self):
+        cls = _find_class(_tree(), "Block")
+        src = _method_src(cls, "forward")
+        # Body must pass forward_batch to self.attn(...) somewhere.
+        assert (
+            "forward_batch=forward_batch" in src
+            or "forward_batch=forward_batch," in src
+            or "forward_batch=forward_batch)" in src
+        ), "Block.forward must pass forward_batch to self.attn(...)"

--- a/tests/test_deepseek_v4_w44_state_redo.py
+++ b/tests/test_deepseek_v4_w44_state_redo.py
@@ -1,0 +1,618 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""W4.4-redo (issue sunway513/atom#37 Tasks 11+12): Compressor / Indexer
+state migration to engine pool.
+
+These tests assert the architectural contract introduced by W4.4-redo:
+
+1. ``Compressor.__init__`` no longer ``register_buffer``s
+   ``kv_state`` / ``score_state``.
+2. ``Indexer.__init__`` no longer ``register_buffer``s ``kv_cache``.
+3. ``Compressor.forward`` accepts ``forward_batch`` + ``layer_id``
+   kwargs and consumes the per-layer pool view.
+4. ``Indexer.forward`` accepts ``forward_batch`` + ``layer_id`` kwargs.
+5. Per-token state writes route to distinct slot rows of the pool's
+   ``kv_state`` / ``score_state`` slabs — no row-0 collision under
+   multi-request decode.
+6. Per-seq compress-boundary check fires ONLY for seqs whose last
+   token's absolute position satisfies ``(p + 1) % ratio == 0``
+   (mirrors SGLang ``compressor.py:236``).
+7. The Indexer's per-seq sparse-index writes (the indexer_kv ring) hit
+   distinct slot rows.
+8. Legacy single-request path is preserved bit-for-bit when
+   ``forward_batch`` is None (PR1 toy / warmup contract).
+
+Why no full-model smoke run? ``DeepseekV4ForCausalLM`` instantiation
+pulls in aiter ROCm kernels (FP8/FP4 GEMMs, sparse_attn) that the
+unit-test image's stubbed ``aiter`` cannot satisfy. We assert the
+contract via:
+
+- AST-level inspection of the source (catches register_buffer
+  regression without an import).
+- Direct invocation of the pool's ``compute_out_cache_loc`` with the
+  same ring-slot math the W4 forward uses internally — no model
+  instantiation needed for the scatter / boundary correctness checks.
+
+The full forward smoke run is silicon-validation territory.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+
+from atom.engine.kv_pool import DSV4KVPool, DSV4KVPoolConfig
+
+# ---------------------------------------------------------------------------
+# Source-level contract checks
+# ---------------------------------------------------------------------------
+
+ATOM_ROOT = Path(__file__).resolve().parent.parent
+DSV4_SOURCE = ATOM_ROOT / "atom" / "models" / "deepseek_v4.py"
+
+
+def _parse_dsv4_source() -> ast.Module:
+    return ast.parse(DSV4_SOURCE.read_text())
+
+
+def _find_class(tree: ast.Module, name: str) -> ast.ClassDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name!r} not found in deepseek_v4.py")
+
+
+def _find_method(cls: ast.ClassDef, name: str) -> ast.FunctionDef:
+    for n in cls.body:
+        if isinstance(n, ast.FunctionDef) and n.name == name:
+            return n
+    raise AssertionError(f"method {name!r} not found on class {cls.name!r}")
+
+
+def _register_buffer_targets(method: ast.FunctionDef) -> list[str]:
+    targets: list[str] = []
+    for node in ast.walk(method):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "register_buffer"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "self"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+            ):
+                targets.append(node.args[0].value)
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# Section 1 — register_buffer absence (W4.4 main contract)
+# ---------------------------------------------------------------------------
+
+
+class TestNoRegisterBufferOnCompressorAndIndexer:
+    """W4.4: Compressor + Indexer state lives in ``DSV4KVPool``, not on
+    the ``nn.Module`` as ``register_buffer``."""
+
+    def test_compressor_kv_state_not_register_buffer(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Compressor")
+        targets = _register_buffer_targets(_find_method(cls, "__init__"))
+        assert (
+            "kv_state" not in targets
+        ), f"Compressor.__init__ must NOT register_buffer 'kv_state'. Found {targets}"
+
+    def test_compressor_score_state_not_register_buffer(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Compressor")
+        targets = _register_buffer_targets(_find_method(cls, "__init__"))
+        assert (
+            "score_state" not in targets
+        ), f"Compressor.__init__ must NOT register_buffer 'score_state'. Found {targets}"
+
+    def test_indexer_kv_cache_not_register_buffer(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Indexer")
+        targets = _register_buffer_targets(_find_method(cls, "__init__"))
+        assert (
+            "kv_cache" not in targets
+        ), f"Indexer.__init__ must NOT register_buffer 'kv_cache'. Found {targets}"
+
+    def test_compressor_state_assigned_as_plain_attribute(self) -> None:
+        """W4.4 sentinel: explicit ``self.kv_state: Optional[...] = None``
+        and ``self.score_state: Optional[...] = None`` plain attribute
+        bindings, lazy-bound to pool view per step."""
+        text = DSV4_SOURCE.read_text()
+        assert (
+            "self.kv_state: Optional[torch.Tensor] = None" in text
+        ), "Compressor.__init__ must initialize self.kv_state as a plain attr."
+        assert (
+            "self.score_state: Optional[torch.Tensor] = None" in text
+        ), "Compressor.__init__ must initialize self.score_state as a plain attr."
+
+    def test_indexer_kv_cache_assigned_as_plain_attribute(self) -> None:
+        """Indexer's W4.4 plain-attribute kv_cache."""
+        cls = _find_class(_parse_dsv4_source(), "Indexer")
+        init = _find_method(cls, "__init__")
+        # find a `self.kv_cache: Optional[torch.Tensor] = None` style
+        # assignment on the Indexer init.
+        found = False
+        for node in ast.walk(init):
+            if isinstance(node, ast.AnnAssign) and isinstance(
+                node.target, ast.Attribute
+            ):
+                if (
+                    node.target.attr == "kv_cache"
+                    and isinstance(node.target.value, ast.Name)
+                    and node.target.value.id == "self"
+                ):
+                    found = True
+                    break
+        assert found, (
+            "Indexer.__init__ must assign self.kv_cache as a typed plain "
+            "attribute (lazy-bound to the pool's indexer_kv view)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section 2 — forward signatures consume forward_batch
+# ---------------------------------------------------------------------------
+
+
+class TestCompressorForwardSignature:
+    """W4.4: Compressor.forward gains ``forward_batch`` + ``layer_id``."""
+
+    def test_compressor_forward_accepts_forward_batch_kwarg(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Compressor")
+        fwd = _find_method(cls, "forward")
+        names = {a.arg for a in fwd.args.args} | {a.arg for a in fwd.args.kwonlyargs}
+        assert (
+            "forward_batch" in names
+        ), f"Compressor.forward must accept 'forward_batch'; got {names}"
+
+    def test_compressor_forward_accepts_layer_id_kwarg(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Compressor")
+        fwd = _find_method(cls, "forward")
+        names = {a.arg for a in fwd.args.args} | {a.arg for a in fwd.args.kwonlyargs}
+        assert (
+            "layer_id" in names
+        ), f"Compressor.forward must accept 'layer_id' for pool layer dispatch; got {names}"
+
+    def test_indexer_forward_accepts_forward_batch_kwarg(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Indexer")
+        fwd = _find_method(cls, "forward")
+        names = {a.arg for a in fwd.args.args} | {a.arg for a in fwd.args.kwonlyargs}
+        assert (
+            "forward_batch" in names
+        ), f"Indexer.forward must accept 'forward_batch'; got {names}"
+
+    def test_indexer_forward_accepts_layer_id_kwarg(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Indexer")
+        fwd = _find_method(cls, "forward")
+        names = {a.arg for a in fwd.args.args} | {a.arg for a in fwd.args.kwonlyargs}
+        assert (
+            "layer_id" in names
+        ), f"Indexer.forward must accept 'layer_id'; got {names}"
+
+
+# ---------------------------------------------------------------------------
+# Section 3 — pool view contract
+# ---------------------------------------------------------------------------
+
+
+def _make_pool_with_compressor() -> DSV4KVPool:
+    """Pool with a c4 layer (compressor + indexer) and a c128 layer
+    (compressor only). Mirrors the layout the W4 attention path
+    consumes per-layer."""
+    cfg = DSV4KVPoolConfig(
+        max_active_seqs=4,
+        num_layers=3,
+        num_c4_layers=1,
+        num_c128_layers=1,
+        head_dim=8,
+        rope_head_dim=4,
+        window_size=16,
+        max_seq_len=128,
+        ring_size_main=16,
+        ring_size_compressor=8,
+        ring_size_indexer=16,
+        compress_ratio_per_layer=[0, 4, 128],
+        state_inner_dim=8,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+        state_dtype=torch.float32,
+    )
+    return DSV4KVPool(cfg)
+
+
+class TestPoolExposesCompressorState:
+    """W4.4: ``view_for_layer`` exposes ``kv_state`` / ``score_state``
+    for compressed layers and ``indexer_kv`` for c4 layers."""
+
+    def test_c4_layer_has_kv_state_and_score_state(self) -> None:
+        pool = _make_pool_with_compressor()
+        view = pool.view_for_layer(layer_id=1)  # c4
+        assert view["kv_state"] is not None, "c4 layer must expose kv_state"
+        assert view["score_state"] is not None, "c4 layer must expose score_state"
+        assert view["indexer_kv"] is not None, "c4 layer must expose indexer_kv"
+
+    def test_c128_layer_has_kv_state_no_indexer(self) -> None:
+        pool = _make_pool_with_compressor()
+        view = pool.view_for_layer(layer_id=2)  # c128
+        assert view["kv_state"] is not None
+        assert view["score_state"] is not None
+        assert view["indexer_kv"] is None, "c128 layer must NOT expose indexer_kv"
+
+    def test_dense_layer_has_no_compressor_state(self) -> None:
+        pool = _make_pool_with_compressor()
+        view = pool.view_for_layer(layer_id=0)  # dense
+        assert view["kv_state"] is None
+        assert view["score_state"] is None
+        assert view["indexer_kv"] is None
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — per-token state scatter (the W4.4 multi-request fix)
+# ---------------------------------------------------------------------------
+
+
+class TestPerTokenCompressorStateScatter:
+    """W4.4: per-token writes to the pool's ``kv_state`` slab must hit
+    distinct slot rows. This is the multi-request decode correctness
+    contract — pre-W4.4, all 4 seqs collapsed onto row 0 of the
+    register_buffer; W4.4 routes each seq to its own slot via the
+    pool's ring-slot math."""
+
+    def test_4seq_decode_kv_state_writes_to_4_distinct_rows(self) -> None:
+        """4 seqs decode 1 token each at distinct positions. The
+        compressor ring's flat slot indices must be unique across the
+        batch."""
+        pool = _make_pool_with_compressor()
+        for sid in [100, 101, 102, 103]:
+            pool.admit_request(sid)
+        slots = pool.get_slots([100, 101, 102, 103])
+
+        positions = torch.tensor([12, 13, 15, 12], dtype=torch.long)
+        cu = torch.tensor([0, 1, 2, 3, 4], dtype=torch.long)
+
+        flat_loc = pool.compute_out_cache_loc(
+            positions=positions,
+            slot_indices=slots,
+            cu_seqlens_q=cu,
+            ring="compressor",
+        )
+        assert flat_loc.shape == (4,)
+        assert (
+            flat_loc.unique().numel() == 4
+        ), f"All 4 tokens must scatter to DISTINCT compressor flat slots. Got {flat_loc.tolist()}"
+
+    def test_compressor_ring_slot_collisions_only_at_modular_wrap(self) -> None:
+        """Two seqs at the same modular position MAY land on the same
+        flat slot ONLY when their slot indices wrap. With distinct
+        slots this MUST not happen — confirms slot isolation."""
+        pool = _make_pool_with_compressor()
+        pool.admit_request(seq_id=10)
+        pool.admit_request(seq_id=11)
+        slots = pool.get_slots([10, 11])
+        positions = torch.tensor([4, 4], dtype=torch.long)
+        cu = torch.tensor([0, 1, 2], dtype=torch.long)
+        flat_loc = pool.compute_out_cache_loc(
+            positions=positions,
+            slot_indices=slots,
+            cu_seqlens_q=cu,
+            ring="compressor",
+        )
+        assert flat_loc[0].item() != flat_loc[1].item(), (
+            "Same-position different-slot tokens must produce different "
+            "flat slots — this is the row-0-collision fix from W4.4."
+        )
+
+    def test_pool_view_kv_state_zero_copy_writes_visible(self) -> None:
+        """Mutating ``view_for_layer(...)["kv_state"]`` must persist
+        across calls (the W4 path's per-step rebinding relies on this)."""
+        pool = _make_pool_with_compressor()
+        for sid in [1, 2]:
+            pool.admit_request(sid)
+        v1 = pool.view_for_layer(layer_id=1)  # c4 layer
+        v1["kv_state"][0, 0, 0] = 99.0
+        v2 = pool.view_for_layer(layer_id=1)
+        assert v2["kv_state"][0, 0, 0].item() == pytest.approx(
+            99.0
+        ), "view_for_layer must return zero-copy slices of pool storage."
+
+    def test_pool_view_score_state_zero_copy_writes_visible(self) -> None:
+        pool = _make_pool_with_compressor()
+        pool.admit_request(7)
+        v1 = pool.view_for_layer(layer_id=2)  # c128 layer
+        v1["score_state"][0, 1, 2] = -1.5
+        v2 = pool.view_for_layer(layer_id=2)
+        assert v2["score_state"][0, 1, 2].item() == pytest.approx(-1.5)
+
+
+# ---------------------------------------------------------------------------
+# Section 5 — per-seq compress-boundary mask
+# ---------------------------------------------------------------------------
+
+
+class TestPerSeqCompressBoundaryMask:
+    """W4.4: a seq triggers a Compressor emission iff its last-token
+    absolute position satisfies ``(p + 1) % ratio == 0``. This is the
+    per-seq mask the W4 forward applies; mirrors SGLang
+    ``compressor.py:236``'s stateless ring math."""
+
+    def _mask_for(self, positions: torch.Tensor, cu: torch.Tensor, ratio: int):
+        """Pure helper reproducing the W4 forward's per-seq trigger."""
+        last_token_idx = cu[1:] - 1
+        last_positions = positions[last_token_idx]
+        return (last_positions + 1) % ratio == 0
+
+    def test_positions_12_13_15_12_ratio_4_only_pos_15_triggers(self) -> None:
+        """Spec example: positions=[12,13,15,12] @ ratio=4 → only the
+        seq at p=15 triggers (15+1=16 ≡ 0 mod 4)."""
+        positions = torch.tensor([12, 13, 15, 12], dtype=torch.long)
+        cu = torch.tensor([0, 1, 2, 3, 4], dtype=torch.long)  # 4 decode seqs
+        mask = self._mask_for(positions, cu, ratio=4)
+        assert mask.tolist() == [
+            False,
+            False,
+            True,
+            False,
+        ], f"only seq at pos=15 should trigger compress; got mask={mask.tolist()}"
+
+    def test_no_seqs_trigger_when_no_position_lands_on_boundary(self) -> None:
+        positions = torch.tensor([10, 14, 18, 22], dtype=torch.long)
+        cu = torch.tensor([0, 1, 2, 3, 4], dtype=torch.long)
+        mask = self._mask_for(positions, cu, ratio=4)
+        assert mask.tolist() == [False, False, False, False]
+
+    def test_all_seqs_trigger_when_all_lands_on_boundary(self) -> None:
+        positions = torch.tensor([3, 7, 11, 15], dtype=torch.long)
+        cu = torch.tensor([0, 1, 2, 3, 4], dtype=torch.long)
+        mask = self._mask_for(positions, cu, ratio=4)
+        assert mask.tolist() == [True, True, True, True]
+
+    def test_mixed_prefill_only_last_token_of_seq_drives_trigger(self) -> None:
+        """Prefill seq spanning multiple tokens: only the seq's LAST
+        token's position drives the compress trigger (cu_seqlens_q
+        encodes the per-seq right-edge)."""
+        # Seq A: tokens at positions [0, 1, 2, 3] (4 prefill tokens) —
+        #   last pos 3, 3+1=4, 4%4=0 → triggers.
+        # Seq B: tokens at positions [10, 11, 12] (3 prefill tokens) —
+        #   last pos 12, 12+1=13, 13%4=1 → does NOT trigger.
+        positions = torch.tensor([0, 1, 2, 3, 10, 11, 12], dtype=torch.long)
+        cu = torch.tensor([0, 4, 7], dtype=torch.long)
+        mask = self._mask_for(positions, cu, ratio=4)
+        assert mask.tolist() == [True, False]
+
+
+# ---------------------------------------------------------------------------
+# Section 6 — Indexer per-seq sparse-index writes
+# ---------------------------------------------------------------------------
+
+
+class TestPerSeqIndexerStateScatter:
+    """W4.4: Indexer's per-seq sparse-index writes (compressed indexer
+    KV) hit distinct slot rows of the pool's ``indexer_kv`` slab."""
+
+    def test_4seq_indexer_writes_distinct_rows(self) -> None:
+        pool = _make_pool_with_compressor()
+        for sid in [200, 201, 202, 203]:
+            pool.admit_request(sid)
+        slots = pool.get_slots([200, 201, 202, 203])
+
+        positions = torch.tensor([15, 19, 23, 27], dtype=torch.long)
+        cu = torch.tensor([0, 1, 2, 3, 4], dtype=torch.long)
+
+        flat_loc = pool.compute_out_cache_loc(
+            positions=positions,
+            slot_indices=slots,
+            cu_seqlens_q=cu,
+            ring="indexer",
+        )
+        assert flat_loc.shape == (4,)
+        assert (
+            flat_loc.unique().numel() == 4
+        ), f"4 seqs must scatter to distinct indexer flat slots. Got {flat_loc.tolist()}"
+
+    def test_indexer_view_zero_copy(self) -> None:
+        """Mutations through ``view_for_layer(...)["indexer_kv"]`` must
+        persist — the Indexer's W4 forward writes through this view."""
+        pool = _make_pool_with_compressor()
+        pool.admit_request(7)
+        v1 = pool.view_for_layer(layer_id=1)  # c4 layer has indexer_kv
+        v1["indexer_kv"][0, 5, 3] = 7.5
+        v2 = pool.view_for_layer(layer_id=1)
+        assert v2["indexer_kv"][0, 5, 3].item() == pytest.approx(7.5)
+
+
+# ---------------------------------------------------------------------------
+# Section 7 — legacy single-request path is preserved
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyPathPreserved:
+    """W4.4 critical guardrail: the W4 path is a NEW path; the legacy
+    single-request fallback (no forward_batch, no pool) must continue
+    to work for warmup / PR1 toy harness."""
+
+    def test_compressor_forward_still_accepts_start_pos_positional(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Compressor")
+        fwd = _find_method(cls, "forward")
+        # Positional args (excluding self): start_pos must be in positional list.
+        positional = [a.arg for a in fwd.args.args]
+        assert (
+            positional[1] == "x"
+        ), f"Compressor.forward arg 1 must be 'x'; got {positional}"
+        assert (
+            "start_pos" in positional
+        ), f"Compressor.forward must keep 'start_pos' for legacy callers; got {positional}"
+
+    def test_indexer_forward_still_accepts_start_pos_offset_positional(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Indexer")
+        fwd = _find_method(cls, "forward")
+        positional = [a.arg for a in fwd.args.args]
+        for required in ("start_pos", "offset"):
+            assert (
+                required in positional
+            ), f"Indexer.forward must keep '{required}' for legacy; got {positional}"
+
+    def test_compressor_has_legacy_state_lazy_allocator(self) -> None:
+        text = DSV4_SOURCE.read_text()
+        assert (
+            "def _ensure_legacy_state" in text
+        ), "Compressor must keep the legacy single-request lazy state allocator."
+
+    def test_indexer_has_legacy_kv_cache_lazy_allocator(self) -> None:
+        text = DSV4_SOURCE.read_text()
+        assert (
+            "def _ensure_legacy_kv_cache" in text
+        ), "Indexer must keep the legacy single-request lazy kv_cache allocator."
+
+
+# ---------------------------------------------------------------------------
+# Section 8 — Compressor / Indexer pool-binding helpers exist
+# ---------------------------------------------------------------------------
+
+
+class TestPoolBindingHelpers:
+    """W4.4 implementation detail: each module exposes a ``_bind_*_from_pool``
+    helper used by ``forward()`` to rebind state to the pool view at
+    every step."""
+
+    def test_compressor_bind_state_from_pool(self) -> None:
+        text = DSV4_SOURCE.read_text()
+        assert (
+            "def _bind_state_from_pool" in text
+        ), "Compressor must expose `_bind_state_from_pool` for the W4 step rebind."
+
+    def test_indexer_bind_kv_cache_from_pool(self) -> None:
+        text = DSV4_SOURCE.read_text()
+        assert (
+            "def _bind_kv_cache_from_pool" in text
+        ), "Indexer must expose `_bind_kv_cache_from_pool` for the W4 step rebind."
+
+    def test_compressor_w4_dispatch_method_exists(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "Compressor")
+        method_names = {n.name for n in cls.body if isinstance(n, ast.FunctionDef)}
+        assert (
+            "_forward_w4" in method_names
+        ), "Compressor must expose `_forward_w4` for the per-token W4 path."
+
+
+# ---------------------------------------------------------------------------
+# Section 9 — Compressor.forward smoke: signature + W4 dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestCompressorForwardW4SmokeRun:
+    """W4.4 smoke: a 4-seq packed input with positions=[12,13,15,12]
+    routes through the W4 path's per-token slot scatter without the
+    register_buffer collision. We can't import Compressor directly
+    (aiter ROCm kernels missing in CI), so we exercise the underlying
+    pool ring math + per-seq compress-trigger logic with a hand-built
+    surrogate that mirrors the production W4 forward exactly."""
+
+    def test_forward_w4_signature_dispatches_on_forward_batch(self) -> None:
+        """Verify the forward dispatch shape — when ``forward_batch`` is
+        provided AND ``forward_batch.kv_pool`` is not None, the W4
+        branch is taken; otherwise the legacy branch."""
+        cls = _find_class(_parse_dsv4_source(), "Compressor")
+        forward_method = _find_method(cls, "forward")
+        body_src = ast.unparse(forward_method)
+        assert "_forward_w4" in body_src, (
+            "Compressor.forward must dispatch to _forward_w4 when "
+            "forward_batch carries a pool."
+        )
+        assert (
+            "kv_pool" in body_src
+        ), "Compressor.forward W4 dispatch must gate on forward_batch.kv_pool."
+        assert "_ensure_legacy_state" in body_src, (
+            "Compressor.forward must call _ensure_legacy_state on the "
+            "legacy fallback path."
+        )
+
+    def test_indexer_forward_dispatches_on_pool_binding(self) -> None:
+        """Indexer.forward calls _bind_kv_cache_from_pool and routes
+        the inner compressor with forward_batch when bound."""
+        cls = _find_class(_parse_dsv4_source(), "Indexer")
+        fwd_method = _find_method(cls, "forward")
+        body_src = ast.unparse(fwd_method)
+        assert "_bind_kv_cache_from_pool" in body_src, (
+            "Indexer.forward must call _bind_kv_cache_from_pool to "
+            "rebind kv_cache to the pool's indexer_kv view."
+        )
+        assert "forward_batch=forward_batch" in body_src, (
+            "Indexer.forward must thread forward_batch into the inner "
+            "compressor on the W4 path."
+        )
+
+    def test_per_token_state_writes_isolate_per_slot(self) -> None:
+        """Reproduces the W4 forward's per-token kv_state scatter on
+        a CPU pool. Each of 4 seqs writes a distinct payload to its
+        OWN slot's ring row; readback confirms no row-0 collision."""
+        pool = _make_pool_with_compressor()
+        for sid in [50, 51, 52, 53]:
+            pool.admit_request(sid)
+        slots = pool.get_slots([50, 51, 52, 53])
+
+        positions = torch.tensor([12, 13, 15, 12], dtype=torch.long)
+
+        # Pull the c4 layer's state slab. ring_compressor=8, ratio=4, so
+        # in overlap mode the "current" half lives at offsets [4..7].
+        view = pool.view_for_layer(layer_id=1)
+        kv_state = view["kv_state"]  # [N=4, ring=8, inner=8]
+        _, _, D = kv_state.shape
+
+        # Reproduce the W4 forward's per-token write:
+        #   row_in_state[t] = ratio + (positions[t] % ratio)
+        ratio = 4
+        row_in_state = ratio + (positions % ratio)
+
+        # Per-seq distinct payloads.
+        payload = torch.arange(4 * D, dtype=torch.float32).view(4, D)
+        kv_state[slots, row_in_state] = payload
+
+        # Read back: each seq's slot has its own row populated, others
+        # remain at the init value (0.0).
+        for i, (slot, pos) in enumerate(zip(slots.tolist(), positions.tolist())):
+            row = ratio + (pos % ratio)
+            assert torch.allclose(
+                kv_state[slot, row], payload[i]
+            ), f"seq {i} (slot={slot}, row={row}) payload mismatch"
+
+        # Confirm no two seqs wrote to the same (slot, row) pair —
+        # this is the multi-request correctness guarantee.
+        seen_keys = {
+            (slot, ratio + (pos % ratio))
+            for slot, pos in zip(slots.tolist(), positions.tolist())
+        }
+        assert (
+            len(seen_keys) == 4
+        ), f"4 seqs must produce 4 distinct (slot, row) write keys; got {seen_keys}"
+
+
+# ---------------------------------------------------------------------------
+# Section 10 — Attention call site updates
+# ---------------------------------------------------------------------------
+
+
+class TestAttentionCallsCompressorIndexerWithLayerId:
+    """W4.4: DeepseekV4Attention._forward_w4 must thread layer_id into
+    Compressor / Indexer calls so they can fetch the correct per-layer
+    pool view."""
+
+    def test_attention_w4_threads_layer_id_into_compressor_or_indexer(self) -> None:
+        cls = _find_class(_parse_dsv4_source(), "DeepseekV4Attention")
+        src = ast.unparse(_find_method(cls, "_forward_w4"))
+        # The W4 path must thread layer_id into compressor or indexer
+        # calls (one or both depending on compress_ratio); for HCA-only
+        # layers the standalone compressor is invoked, for C4 the
+        # Indexer wraps the inner compressor.
+        threaded = "layer_id=self.layer_id" in src or "layer_id=" in src
+        assert threaded, (
+            "DeepseekV4Attention._forward_w4 must pass layer_id=self.layer_id "
+            "into compressor / indexer calls so they can fetch the right "
+            "per-layer pool view."
+        )

--- a/tests/test_dsv4_multireq_guard.py
+++ b/tests/test_dsv4_multireq_guard.py
@@ -69,13 +69,65 @@ class TestValidateDsv4Multireq:
         _validate_dsv4_multireq(architectures=["DeepseekV4ForCausalLM"], max_num_seqs=1)
 
     def test_dsv4_arch_with_override_accepts_max_num_seqs_4(self):
-        with patch.dict(os.environ, {"ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1"}):
+        # Post-W4.3 spec: BOTH flags required (double opt-in).
+        with patch.dict(
+            os.environ,
+            {
+                "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1",
+                "ATOM_DSV4_USE_W4_PATH": "1",
+            },
+        ):
             # Re-import envs so the lazy lambda re-reads os.environ.
             import importlib
 
             from atom.utils import envs as envs_mod
 
             importlib.reload(envs_mod)
+            _validate_dsv4_multireq(
+                architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+            )
+
+    def test_unsafe_alone_now_rejects(self):
+        """Post-W4.3 spec: UNSAFE=1 alone is no longer enough — also need USE_W4_PATH=1."""
+        with patch.dict(os.environ, {"ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1"}):
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            with pytest.raises(ValueError, match="ATOM_DSV4_USE_W4_PATH"):
+                _validate_dsv4_multireq(
+                    architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+                )
+
+    def test_use_w4_alone_rejects(self):
+        with patch.dict(os.environ, {"ATOM_DSV4_USE_W4_PATH": "1"}):
+            os.environ.pop("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            with pytest.raises(ValueError, match="ATOM_DSV4_UNSAFE_MULTIREQ_DEV"):
+                _validate_dsv4_multireq(
+                    architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
+                )
+
+    def test_both_flags_allow_multireq(self):
+        with patch.dict(
+            os.environ,
+            {
+                "ATOM_DSV4_UNSAFE_MULTIREQ_DEV": "1",
+                "ATOM_DSV4_USE_W4_PATH": "1",
+            },
+        ):
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            # Should not raise
             _validate_dsv4_multireq(
                 architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
             )
@@ -107,14 +159,15 @@ class TestValidateDsv4Multireq:
     def test_error_message_points_users_to_remediation(self):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("ATOM_DSV4_UNSAFE_MULTIREQ_DEV", None)
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
             with pytest.raises(ValueError) as exc_info:
                 _validate_dsv4_multireq(
                     architectures=["DeepseekV4ForCausalLM"], max_num_seqs=4
                 )
             msg = str(exc_info.value)
             assert "issues/37" in msg
-            assert "ATOM_DSV4_UNSAFE_MULTIREQ_DEV=1" in msg
-            assert "feat/dsv4-forward-batch-paged-kv" in msg
+            assert "ATOM_DSV4_UNSAFE_MULTIREQ_DEV" in msg
+            assert "ATOM_DSV4_USE_W4_PATH" in msg
 
 
 class TestConfigIntegration:

--- a/tests/test_dsv4_multireq_guard.py
+++ b/tests/test_dsv4_multireq_guard.py
@@ -193,3 +193,32 @@ class TestDSV4UnsafeMultireqDevEnv:
 
             importlib.reload(envs_mod)
             assert envs_mod.ATOM_DSV4_UNSAFE_MULTIREQ_DEV is False
+
+    def test_use_w4_path_default_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ATOM_DSV4_USE_W4_PATH", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_DSV4_USE_W4_PATH is False
+
+    def test_use_w4_path_set_true(self):
+        with patch.dict(os.environ, {"ATOM_DSV4_USE_W4_PATH": "1"}):
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_DSV4_USE_W4_PATH is True
+
+    def test_aiter_validate_default_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ATOM_AITER_VALIDATE", None)
+            import importlib
+
+            from atom.utils import envs as envs_mod
+
+            importlib.reload(envs_mod)
+            assert envs_mod.ATOM_AITER_VALIDATE is False

--- a/tests/test_modelrunner_dsv4_pool_lifecycle.py
+++ b/tests/test_modelrunner_dsv4_pool_lifecycle.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""ModelRunner is the sole owner of DSV4KVPool (issue sunway513/atom#37 P2.2).
+
+Verifies the canonical #42 fix: ``is_dummy_run`` short-circuit at the very
+entry of ``_maybe_setup_dsv4_forward_batch`` + ``ATOM_DSV4_USE_W4_PATH``
+gate. Both must pass before the pool is touched.
+
+Additionally validates:
+- pool finish_request is idempotent under preempt-then-finish race.
+- ModelRunner._build_dsv4_pool wires the pool's finish_request into
+  the scheduler's finish-listener registry (P2.2 ownership boundary).
+
+These tests do NOT exercise live cudagraph or real model construction;
+they exercise the pure pool-lifecycle helper using ``unittest.mock``.
+
+Heavy aiter / model-loader imports at the top of ``model_runner.py`` are
+stubbed below so the module is importable without GPU dependencies.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-import: stub the heavy chain that atom.model_engine.model_runner pulls
+# in at module level (aiter, model_loader, kv_transfer, etc.).
+# Must run before any `from atom.model_engine.model_runner import ModelRunner`.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+    return sys.modules[name]
+
+
+def _stub_modelrunner_imports() -> None:
+    # aiter top-level: model_runner does
+    #   from aiter import destroy_dist_env, dtypes, init_dist_env
+    _aiter = _ensure_module("aiter")
+    for fn in ("destroy_dist_env", "init_dist_env"):
+        if not hasattr(_aiter, fn):
+            setattr(_aiter, fn, lambda *a, **kw: None)
+    if not hasattr(_aiter, "dtypes"):
+        _aiter.dtypes = types.SimpleNamespace()
+
+    # aiter.dist.parallel_state — extra symbols beyond conftest's stubs.
+    _ps = _ensure_module("aiter.dist.parallel_state")
+    for fn in ("get_dp_group", "get_pp_group", "get_tp_group", "graph_capture"):
+        if not hasattr(_ps, fn):
+            setattr(_ps, fn, lambda *a, **kw: None)
+
+    # aiter.dist.utils — get_distributed_init_method
+    _du = _ensure_module("aiter.dist.utils")
+    if not hasattr(_du, "get_distributed_init_method"):
+        _du.get_distributed_init_method = lambda *a, **kw: ""
+
+    # atom.model_loader.loader — load_model
+    _ml_pkg = _ensure_module("atom.model_loader")
+    _ml_pkg.__path__ = []
+    _ml = _ensure_module("atom.model_loader.loader")
+    if not hasattr(_ml, "load_model"):
+        _ml.load_model = lambda *a, **kw: None
+
+    # atom.model_ops.* — RejectionSampler, sampler, etc.
+    _mo_pkg = _ensure_module("atom.model_ops")
+    _mo_pkg.__path__ = []
+    _rj = _ensure_module("atom.model_ops.rejection_sampler")
+    if not hasattr(_rj, "RejectionSampler"):
+        _rj.RejectionSampler = type("RejectionSampler", (), {})
+    _sm = _ensure_module("atom.model_ops.sampler")
+    if not hasattr(_sm, "SAMPLER_EPS"):
+        _sm.SAMPLER_EPS = 1e-6
+    if not hasattr(_sm, "Sampler"):
+        _sm.Sampler = type("Sampler", (), {})
+
+    # atom.spec_decode.eagle — EagleProposer
+    _sd_pkg = _ensure_module("atom.spec_decode")
+    _sd_pkg.__path__ = []
+    _ea = _ensure_module("atom.spec_decode.eagle")
+    if not hasattr(_ea, "EagleProposer"):
+        _ea.EagleProposer = type("EagleProposer", (), {})
+
+    # atom.kv_transfer.disaggregation — KVConnectorOutput
+    _kt_pkg = _ensure_module("atom.kv_transfer")
+    _kt_pkg.__path__ = []
+    _dg = _ensure_module("atom.kv_transfer.disaggregation")
+    if not hasattr(_dg, "KVConnectorOutput"):
+        _dg.KVConnectorOutput = type("KVConnectorOutput", (), {})
+
+    # atom.utils submodules used by model_runner
+    _u_pkg = _ensure_module("atom.utils")
+    _u_pkg.__path__ = [
+        __import__("os").path.join(
+            __import__("os").path.dirname(__import__("os").path.dirname(__file__)),
+            "atom",
+            "utils",
+        )
+    ]
+    # tbo, selector — stub to avoid heavy chain
+    _tbo = _ensure_module("atom.utils.tbo")
+    if not hasattr(_tbo, "UBatchWrapper"):
+        _tbo.UBatchWrapper = type("UBatchWrapper", (), {})
+    if not hasattr(_tbo, "maybe_create_ubatch_slices"):
+        _tbo.maybe_create_ubatch_slices = lambda *a, **kw: None
+    _sel = _ensure_module("atom.utils.selector")
+    if not hasattr(_sel, "get_attn_backend"):
+        _sel.get_attn_backend = lambda *a, **kw: None
+
+    # atom.config — extra symbol set_current_atom_config
+    _cfg = sys.modules.get("atom.config")
+    if _cfg is not None and not hasattr(_cfg, "set_current_atom_config"):
+        _cfg.set_current_atom_config = lambda *a, **kw: None
+
+    # atom.utils.__init__ — model_runner does
+    #   from atom.utils import (CpuGpuBuffer, envs, get_hf_text_config,
+    #       init_exit_handler, resolve_obj_by_qualname)
+    if not hasattr(_u_pkg, "CpuGpuBuffer"):
+        _u_pkg.CpuGpuBuffer = type("CpuGpuBuffer", (), {})
+    if not hasattr(_u_pkg, "envs"):
+        from atom.utils import envs as _envs
+
+        _u_pkg.envs = _envs
+    if not hasattr(_u_pkg, "get_hf_text_config"):
+        _u_pkg.get_hf_text_config = lambda cfg: cfg
+    if not hasattr(_u_pkg, "init_exit_handler"):
+        _u_pkg.init_exit_handler = lambda *a, **kw: None
+    if not hasattr(_u_pkg, "resolve_obj_by_qualname"):
+        _u_pkg.resolve_obj_by_qualname = lambda name: None
+    # graph_marker referenced by model_runner.__init__
+    _gm = _ensure_module("atom.utils.graph_marker")
+    if not hasattr(_gm, "set_graph_marker_enabled"):
+        _gm.set_graph_marker_enabled = lambda *a, **kw: None
+
+
+_stub_modelrunner_imports()
+
+
+# ---------------------------------------------------------------------------
+# Pool gating tests — the canonical #42 fix
+# ---------------------------------------------------------------------------
+
+
+class TestPoolGating:
+    def test_dummy_run_returns_none_none(self, monkeypatch):
+        """The canonical #42 fix: is_dummy_run short-circuits before pool admit."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        monkeypatch.setenv("ATOM_DSV4_USE_W4_PATH", "1")
+        # reload envs to pick up the new value
+        from atom.utils import envs as envs_mod
+
+        importlib.reload(envs_mod)
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = True
+        runner._dsv4_pool = MagicMock()  # if already inited
+
+        dummy_batch = MagicMock()
+        dummy_batch.is_dummy_run = True
+        dummy_batch.req_ids = [0, 1, 2, 3]
+
+        # Bind the real method to the mock
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            dummy_batch,
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+        # Critical: pool admit_request must NOT have been called
+        runner._dsv4_pool.admit_request.assert_not_called()
+
+    def test_flag_off_returns_none_none(self, monkeypatch):
+        """``ATOM_DSV4_USE_W4_PATH=0`` => also short-circuit."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        monkeypatch.setenv("ATOM_DSV4_USE_W4_PATH", "0")
+        from atom.utils import envs as envs_mod
+
+        importlib.reload(envs_mod)
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = True
+
+        real_batch = MagicMock()
+        real_batch.is_dummy_run = False
+        real_batch.req_ids = [0, 1]
+
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            real_batch,
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+
+    def test_non_dsv4_model_returns_none_none(self):
+        """Non-DSV4 models pass through untouched."""
+        from atom.model_engine.model_runner import ModelRunner
+
+        runner = MagicMock(spec=ModelRunner)
+        runner._is_dsv4_model.return_value = False
+
+        pool, fb = ModelRunner._maybe_setup_dsv4_forward_batch(
+            runner,
+            batch=MagicMock(),
+            attn_metadata=MagicMock(),
+            positions=MagicMock(),
+        )
+        assert pool is None
+        assert fb is None
+
+
+# ---------------------------------------------------------------------------
+# finish_request idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestFinishIdempotent:
+    def test_pool_finish_called_twice_is_safe(self):
+        """ModelRunner subscribes pool.finish_request to scheduler events.
+        finish_request must be idempotent under preempt-then-finish race.
+        """
+        import torch
+
+        from atom.engine.kv_pool.dsv4_pool import DSV4KVPool, DSV4KVPoolConfig
+
+        ratios = [4, 4, 128, 128]
+        cfg = DSV4KVPoolConfig(
+            max_active_seqs=4,
+            num_layers=4,
+            num_c4_layers=2,
+            num_c128_layers=2,
+            head_dim=32,
+            rope_head_dim=16,
+            window_size=32,
+            max_seq_len=128,
+            ring_size_main=32,
+            ring_size_compressor=8,
+            ring_size_indexer=32,
+            compress_ratio_per_layer=ratios,
+            state_inner_dim=32,
+            dtype=torch.float32,
+            state_dtype=torch.float32,
+            device=torch.device("cpu"),
+        )
+        pool = DSV4KVPool(cfg)
+        pool.admit_request(seq_id=0)
+        pool.finish_request(seq_id=0)
+        # Second call must not raise (idempotent)
+        pool.finish_request(seq_id=0)
+        # Third call also OK (never admitted; defensive no-op)
+        pool.finish_request(seq_id=999)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler subscription wiring (structural smoke check)
+# ---------------------------------------------------------------------------
+
+
+class TestNoDsv4ScheduleListener:
+    def test_modelrunner_subscribes_pool_to_scheduler(self):
+        """The wiring: ``ModelRunner._build_dsv4_pool`` source must reference
+        ``register_finish_listener`` (preferred) or at least the scheduler.
+
+        Smoke-style assertion since constructing a full ModelRunner+Scheduler
+        integration is too heavy for a unit test.
+        """
+        import inspect
+
+        from atom.model_engine.model_runner import ModelRunner
+
+        if hasattr(ModelRunner, "_build_dsv4_pool"):
+            src = inspect.getsource(ModelRunner._build_dsv4_pool)
+            assert "register_finish_listener" in src or "scheduler" in src.lower()
+        else:
+            pytest.skip("_build_dsv4_pool not yet implemented")

--- a/tests/test_scheduler_lifecycle_events.py
+++ b/tests/test_scheduler_lifecycle_events.py
@@ -1,0 +1,64 @@
+"""Scheduler emits seq lifecycle events via callback registry (issue #37 W4.3 P2.2).
+
+Establishes the ownership boundary: Scheduler does not know DSV4KVPool
+exists; ModelRunner subscribes pool.admit_request / pool.finish_request
+to these events.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestEventRegistry:
+    def test_admit_listener_registry_exists(self, scheduler):
+        """Public API: register_admit_listener(fn) appends fn to the registry."""
+        listener = MagicMock()
+        scheduler.register_admit_listener(listener)
+        assert listener in scheduler._admit_listeners
+
+    def test_finish_listener_registry_exists(self, scheduler):
+        listener = MagicMock()
+        scheduler.register_finish_listener(listener)
+        assert listener in scheduler._finish_listeners
+
+    def test_emit_admit_calls_all_admit_listeners(self, scheduler):
+        l1, l2 = MagicMock(), MagicMock()
+        scheduler.register_admit_listener(l1)
+        scheduler.register_admit_listener(l2)
+        scheduler._emit_admit(seq_id=42)
+        l1.assert_called_once_with(42)
+        l2.assert_called_once_with(42)
+
+    def test_emit_finish_calls_all_finish_listeners(self, scheduler):
+        l1, l2 = MagicMock(), MagicMock()
+        scheduler.register_finish_listener(l1)
+        scheduler.register_finish_listener(l2)
+        scheduler._emit_finish(seq_id=99)
+        l1.assert_called_once_with(99)
+        l2.assert_called_once_with(99)
+
+    def test_listener_exception_does_not_propagate(self, scheduler):
+        """A bad listener cannot break the scheduler."""
+        bad = MagicMock(side_effect=RuntimeError("oops"))
+        good = MagicMock()
+        scheduler.register_admit_listener(bad)
+        scheduler.register_admit_listener(good)
+        # Must not raise
+        scheduler._emit_admit(seq_id=1)
+        good.assert_called_once_with(1)
+
+
+class TestNoDsv4PoolImport:
+    def test_scheduler_source_does_not_reference_dsv4_pool(self):
+        """Ownership boundary check: scheduler.py must not import DSV4KVPool.
+
+        ModelRunner subscribes the pool's admit/finish methods to the
+        scheduler's events. The scheduler itself is pool-agnostic.
+        """
+        import atom.model_engine.scheduler as sched_mod
+
+        with open(sched_mod.__file__) as f:
+            src = f.read()
+        # The scheduler may have generic listener bookkeeping but must not
+        # know about DSV4KVPool specifically.
+        assert "DSV4KVPool" not in src
+        assert "dsv4_pool" not in src.lower()


### PR DESCRIPTION
## Summary

Tasks 11 + 12 of issue #37 (DSV4 W4.3-redo Sprint), combined into one PR
because they're symmetric work on the same file with the same pattern.

This PR completes the multi-request KV-cache reform by lifting the
remaining per-request state (Compressor's `kv_state` / `score_state`,
Indexer's `kv_cache`) out of `nn.Module` `register_buffer`s and into
the engine `DSV4KVPool` (W4.3 Task 9 lifted the main attention; W4.4
finishes the migration).

### Compressor changes
- `kv_state` / `score_state` are plain `Optional[torch.Tensor]`
  attributes, NOT `register_buffer`s.
- W4 path: lazy-bound to the per-layer pool view via
  `_bind_state_from_pool` (zero-copy slice).
- Legacy path: lazy-allocated locally via `_ensure_legacy_state`
  matching the pre-W4.4 shape.
- New `_forward_w4(x, forward_batch, layer_id)`: per-token state
  scatter via 2D advanced indexing `(slot_per_token, row_in_state)`,
  per-seq compress-boundary check `(positions[t] + 1) % ratio == 0`
  (mirrors SGLang `compressor.py:236`), per-seq compressed-cache
  scatter via `kv_cache[slot, p_last // ratio]`.
- `forward(x, start_pos=0, *, forward_batch=None, layer_id=None)`.

### Indexer changes
- `kv_cache` is a plain `Optional[torch.Tensor]` attribute, NOT a
  `register_buffer`.
- W4 path: rebound to the pool's `indexer_kv` view via
  `_bind_kv_cache_from_pool`.
- Legacy path: lazy-allocated locally via `_ensure_legacy_kv_cache`.
- `forward(x, qr, start_pos, offset, *, forward_batch=None, layer_id=None)`.
- Inner Compressor invoked with `forward_batch=...` + `layer_id=...`
  on the W4 path.

### DeepseekV4Attention call site
`_forward_w4` (Task 10) now drives:
- C4 layers: `self.indexer(..., forward_batch=forward_batch, layer_id=self.layer_id)`
- HCA-only layers (no Indexer): `self.compressor(x, forward_batch=forward_batch, layer_id=self.layer_id)`

Per-seq compress-boundary trigger uses `cu_seqlens_q[1:]-1` modular
ring math, eliminating the per-batch scalar `start_pos` boundary that
broke W3.2-v3..v6.1.

### Legacy path preservation
The legacy single-request path (`forward_batch=None`) is preserved
bit-for-bit. The legacy reset block guards on `is not None` because
the lazy state allocators only fire on the first compressor / indexer
call (matters for warmup / PR1 toy / single-seq eager).

## Tests

Cumulative DSV4 reform tests: **248 passing**
- `tests/test_deepseek_v4_w44_state_redo.py` (NEW, 33 tests):
  - register_buffer absence (5)
  - forward signature contracts (4)
  - pool view exposes per-layer kv_state / score_state / indexer_kv (3)
  - per-token state scatter to distinct slot rows (4)
  - per-seq compress-boundary mask (4)
  - Indexer per-seq sparse-index writes (2)
  - legacy path preserved (4)
  - pool-binding helpers exist (3)
  - Compressor W4 dispatch + per-slot isolation smoke (3)
  - Attention call site threads layer_id (1)
- All pre-existing W4.x and base tests continue passing (215).

```
docker exec atom_dsv4_feat bash -c "cd /workspace/ATOM-lingpeng && /opt/venv/bin/python -m pytest \\
  tests/test_deepseek_v4_w44_state_redo.py tests/test_deepseek_v4_w43_redo.py \\
  tests/test_dsv4_pool.py tests/test_dsv4_forward_batch.py \\
  tests/test_dsv4_multireq_guard.py tests/test_scheduler_lifecycle_events.py \\
  tests/test_modelrunner_dsv4_pool_lifecycle.py tests/test_block_manager.py \\
  tests/test_block_manager_multipool.py tests/test_kv_cache_interface.py \\
  tests/test_scheduler.py tests/test_sequence.py tests/test_sequence_block_tables.py"
# ===== 248 passed in 1.83s =====
```

`black --target-version py312` + `ruff check` clean.

## Test plan
- [x] Source-level AST inspection for register_buffer absence
- [x] Pool view exposes correct per-layer slabs (kv_state/score_state for c4+c128, indexer_kv for c4)
- [x] Per-token slot scatter produces distinct flat indices (no row-0 collision)
- [x] Per-seq compress-boundary mask matches SGLang spec
- [x] Legacy lazy allocator + pool-binding helpers exist
- [x] Forward signatures preserve `start_pos` positional for legacy callers
- [ ] Silicon validation (out of scope — Task 14)

## Out of scope
- Silicon validation (full-model smoke run on GPU) — Task 14
- CUDAGraph capture optimization
- Per-layer compressed-cache slab in pool (today the standalone
  Compressor's HCA-layer `kv_cache` write target is still a layer-
  local fallback; W4.5+ silicon work)

Refs: sunway513/atom#37

🤖 Generated with [Claude Code](https://claude.com/claude-code)